### PR TITLE
Implement Generator and DiscreteGenerator for slice references

### DIFF
--- a/src/base/mod.rs
+++ b/src/base/mod.rs
@@ -43,6 +43,19 @@ impl<T: Copy> DiscreteGenerator for Vec<T> {
 //     }
 // }
 
+impl<T: Copy> Generator<usize> for &[T] {
+    type Output = T;
+    fn gen(&self, input: usize) -> Self::Output {
+        self[input]
+    }
+}
+
+impl<T: Copy> DiscreteGenerator for &[T] {
+    fn len(&self) -> usize {
+        <[T]>::len(self)
+    }
+}
+
 impl<T: Copy, const N: usize> Generator<usize> for [T; N] {
     type Output = T;
     fn gen(&self, input: usize) -> Self::Output {


### PR DESCRIPTION
Allowing `elements` to be provided in a more generic way.

Arguably this makes the impl for Vec unnecessary as Vec is trivially cast with `as_slice`, however removing that would be a breaking change.