### PR TITLE
Update GitHub Actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,24 +20,19 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@master
         id: toolchain
         with:
-          profile: minimal
           toolchain: ${{ matrix.rust }}
-          override: true
           components: rustfmt, clippy
 
       - name: clippy
         if: matrix.os == 'ubuntu-latest' && matrix.rust == 'stable'
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: -- -D warnings
+        run: cargo clippy -- -D warnings
 
       - name: cache cargo binaries
         id: cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: "/usr/share/rust/.cargo"
           key: ${{ runner.os }}-cargo-bins-${{ env.GITHUB_SHA }}
@@ -45,24 +40,14 @@ jobs:
 
       - name: install tools
         if: steps.cache.outputs.cache_hit != 'true'
-        uses: actions-rs/cargo@v1
-        with:
-          command: install
-          args: --git https://github.com/NicolasKlenert/cargo-all-features.git
+        run: cargo install --git https://github.com/NicolasKlenert/cargo-all-features.git
 
       # - name: install tools
       #   if: steps.cache.outputs.cache_hit != 'true'
-      #   uses: actions-rs/cargo@v1
-      #   with:
-      #     command: install
-      #     args: cargo-nono --locked
+      #   run: cargo install cargo-nono --locked
 
       - name: Run Tests
-        uses: actions-rs/cargo@v1
-        with:
-          command: test-all-features
+        run: cargo test-all-features
 
       # - name: test no-std
-      #   uses: actions-rs/cargo@v1
-      #   with:
-      #     command: nono check --no-default-features --features libm serde linear bezier bspline
+      #   run: cargo nono check --no-default-features --features libm serde linear bezier bspline


### PR DESCRIPTION
The following updates are performed:
* update [`actions/cache`](https://github.com/actions/cache) to v3
* replace [unmaintained](https://github.com/actions-rs/toolchain/issues/216) `actions-rs/toolchain` by [`dtolnay/rust-toolchain`](https://github.com/dtolnay/rust-toolchain)
* replace unmaintained `actions-rs/cargo` by direct invocation of `cargo`

Still using the outdated / unmaintained actions will generate several warnings in CI runs, for example in https://github.com/NicolasKlenert/enterpolation/actions/runs/5170767574:

> Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions-rs/toolchain@v1, actions/cache@v2, actions-rs/cargo@v1. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.

The PR will get rid of those warnings.