### PR TITLE
Rename `gen` method to `interpolate`, and remove unused imports in examples

### DIFF
--- a/examples/bspline_reasoning.rs
+++ b/examples/bspline_reasoning.rs
@@ -1,6 +1,6 @@
 //! This example shall illustrate bsplines and how to corrolate to other curves.
 
-use assert_float_eq::{afe_is_f64_near, afe_near_error_msg, assert_f64_near};
+use assert_float_eq::assert_f64_near;
 use enterpolation::{bezier::Bezier, bspline::BSpline, linear::Linear, Curve};
 
 fn main() {

--- a/examples/gradient.rs
+++ b/examples/gradient.rs
@@ -48,7 +48,9 @@ fn main() {
     let mut imgbuf = ImageBuffer::new(width, height);
 
     for (x, _, pixel) in imgbuf.enumerate_pixels_mut() {
-        let hsl = spline.gen(remap(x as f32, 0.0, width as f32, dmin, dmax)).0;
+        let hsl = spline
+            .interpolate(remap(x as f32, 0.0, width as f32, dmin, dmax))
+            .0;
         let srgb: palette::Srgb = hsl.into_color();
         let raw: (u8, u8, u8) = srgb.into_format().into_components();
         *pixel = Rgba([raw.0, raw.1, raw.2, 255]);

--- a/examples/noise.rs
+++ b/examples/noise.rs
@@ -11,7 +11,7 @@ struct ValueGenerator {}
 
 impl Generator<usize> for ValueGenerator {
     type Output = f64;
-    fn gen(&self, input: usize) -> f64 {
+    fn interpolate(&self, input: usize) -> f64 {
         // In Reality we would want to use a hash-like function
         // otherwise we don't create noise but a simple pattern
         (input % 10) as f64
@@ -43,7 +43,11 @@ fn main() {
     // lands on an integer we know that values at x and x+10.0 are equal.
     let samples = [3.3, 157.23, 989.98];
     for sample in samples.iter() {
-        assert_f64_near!(spline.gen(sample), spline.gen(sample + 10.0), 10);
+        assert_f64_near!(
+            spline.interpolate(sample),
+            spline.interpolate(sample + 10.0),
+            10
+        );
     }
     println!("Nearly infinite long curve generated!");
 }

--- a/examples/noise.rs
+++ b/examples/noise.rs
@@ -3,7 +3,7 @@
 //! Enterpolation is written to be as generic as possible and using a generator
 //! instead of a collection allows to define a (nearly) infinite detail-rich interpolation.
 
-use assert_float_eq::{afe_is_f64_near, afe_near_error_msg, assert_f64_near};
+use assert_float_eq::assert_f64_near;
 use enterpolation::{bspline::BSpline, DiscreteGenerator, Generator};
 
 // We define our own value generator which will be the basis of our (nearly) infinite curve.

--- a/examples/nurbs.rs
+++ b/examples/nurbs.rs
@@ -113,7 +113,7 @@ fn main() {
     for val in [0.0f64, 1.0, 2.0, 3.0, 4.0].iter().copied() {
         // scale value to the corresponding circumference
         let circle_point = Point::new((val * 0.5 * PI).cos(), (val * 0.5 * PI).sin());
-        assert_float_absolute_eq!(nurbs.gen(val).dist(circle_point), 0.0);
+        assert_float_absolute_eq!(nurbs.interpolate(val).dist(circle_point), 0.0);
     }
     println!("Successful creation of unit circle with a NURBS!");
     // but we can approximate it by linearizing.

--- a/examples/nurbs.rs
+++ b/examples/nurbs.rs
@@ -9,8 +9,8 @@ use core::ops::{Add, Div, Mul, Sub};
 use enterpolation::{bspline::BSpline, Curve, Generator};
 // used to test equality of f64s
 use assert_float_eq::{
-    afe_abs, afe_absolute_error_msg, afe_is_absolute_eq, afe_is_f64_near, afe_near_error_msg,
-    assert_f64_near, assert_float_absolute_eq,
+    afe_abs, afe_is_absolute_eq, afe_is_f64_near, afe_near_error_msg, assert_f64_near,
+    assert_float_absolute_eq,
 };
 
 /// We create our own 2D Point

--- a/examples/nurbs.rs
+++ b/examples/nurbs.rs
@@ -8,10 +8,7 @@ use core::f64::consts::PI;
 use core::ops::{Add, Div, Mul, Sub};
 use enterpolation::{bspline::BSpline, Curve, Generator};
 // used to test equality of f64s
-use assert_float_eq::{
-    afe_abs, afe_is_absolute_eq, afe_is_f64_near, afe_near_error_msg, assert_f64_near,
-    assert_float_absolute_eq,
-};
+use assert_float_eq::{assert_f64_near, assert_float_absolute_eq};
 
 /// We create our own 2D Point
 #[derive(Debug, Copy, Clone)]

--- a/examples/plateaus.rs
+++ b/examples/plateaus.rs
@@ -74,10 +74,10 @@ fn main() {
     for (x, y, pixel) in imgbuf.enumerate_pixels_mut() {
         let raw = if y <= upper_height {
             gradient
-                .gen(remap(x as f32, 0.0, width as f32, dmin, dmax))
+                .interpolate(remap(x as f32, 0.0, width as f32, dmin, dmax))
                 .get_raw()
         } else {
-            let graph = lin.gen(remap(x as f32, 0.0, width as f32, dmin, dmax));
+            let graph = lin.interpolate(remap(x as f32, 0.0, width as f32, dmin, dmax));
             let graph = remap(graph, omin, omax, 0.0, 1.0);
             // test if pixel falls into the area of the graph
             if (graph
@@ -94,7 +94,7 @@ fn main() {
                 [0, 0, 0]
             } else {
                 plateaus
-                    .gen(remap(x as f32, 0.0, width as f32, dmin, dmax))
+                    .interpolate(remap(x as f32, 0.0, width as f32, dmin, dmax))
                     .get_raw()
             }
         };

--- a/src/base/list.rs
+++ b/src/base/list.rs
@@ -75,7 +75,7 @@ pub trait SortedGenerator: DiscreteGenerator {
         while dist > 0 {
             let step = dist / 2;
             let sample = pointer + step;
-            if element >= self.gen(sample) {
+            if element >= self.interpolate(sample) {
                 pointer = sample + 1;
                 dist -= step + 1;
             } else {
@@ -145,8 +145,8 @@ pub trait SortedGenerator: DiscreteGenerator {
     /// let values = vec![-1.0,0.0,0.15,0.7,1.0,20.0];
     /// for value in values {
     ///     let (min_index, max_index, factor) = arr.upper_border(value);
-    ///     let min = arr.gen(min_index);
-    ///     let max = arr.gen(max_index);
+    ///     let min = arr.interpolate(min_index);
+    ///     let max = arr.interpolate(max_index);
     ///     assert_f64_near!(utils::lerp(min,max,factor),value);
     /// }
     /// ```
@@ -161,8 +161,8 @@ pub trait SortedGenerator: DiscreteGenerator {
     /// for (value, result) in values.into_iter().zip(results) {
     ///     let (min_index, max_index, factor) = arr.upper_border(value);
     ///     println!("min_index: {:?}, max_index: {:?}, factor: {:?}", min_index, max_index, factor);
-    ///     let min = arr.gen(min_index);
-    ///     let max = arr.gen(max_index);
+    ///     let min = arr.interpolate(min_index);
+    ///     let max = arr.interpolate(max_index);
     ///     assert_f64_near!(utils::lerp(min,max,factor),result);
     /// }
     /// ```
@@ -218,8 +218,8 @@ pub trait SortedGenerator: DiscreteGenerator {
     where
         Self::Output: Sub<Output = Self::Output> + Div<Output = Self::Output> + Copy,
     {
-        let max = self.gen(max_index);
-        let min = self.gen(min_index);
+        let max = self.interpolate(max_index);
+        let min: <Self as Generator<usize>>::Output = self.interpolate(min_index);
         (element - min) / (max - min)
     }
 
@@ -238,8 +238,8 @@ pub trait SortedGenerator: DiscreteGenerator {
     where
         Self::Output: Sub<Output = Self::Output> + Div<Output = Self::Output> + Zero + Copy,
     {
-        let max = self.gen(max_index);
-        let min = self.gen(min_index);
+        let max = self.interpolate(max_index);
+        let min = self.interpolate(min_index);
         let div = max - min;
         if div.is_zero() {
             return div;
@@ -264,9 +264,9 @@ where
         if col.is_empty() {
             return Ok(Sorted(col));
         }
-        let mut last = col.gen(0);
+        let mut last = col.interpolate(0);
         for i in 1..col.len() {
-            let current = col.gen(i);
+            let current = col.interpolate(i);
             match last.partial_cmp(&current) {
                 None | Some(Ordering::Greater) => return Err(NotSorted { index: i }),
                 _ => {
@@ -293,8 +293,8 @@ where
     C: Generator<usize>,
 {
     type Output = C::Output;
-    fn gen(&self, input: usize) -> Self::Output {
-        self.0.gen(input)
+    fn interpolate(&self, input: usize) -> Self::Output {
+        self.0.interpolate(input)
     }
 }
 
@@ -413,7 +413,7 @@ where
     R: Real + FromPrimitive,
 {
     type Output = R;
-    fn gen(&self, input: usize) -> R {
+    fn interpolate(&self, input: usize) -> R {
         self.step * R::from_usize(input).unwrap() + self.offset
     }
 }
@@ -478,7 +478,7 @@ where
         Self::Output: PartialOrd + Copy,
     {
         // extrapolation to the left
-        if element < self.gen(min) {
+        if element < self.interpolate(min) {
             return min;
         }
         let scaled = (element - self.offset) / self.step;
@@ -524,8 +524,8 @@ where
     /// let values = vec![-1.0,0.0,0.15,0.6,1.0,20.0];
     /// for value in values {
     ///     let (min_index, max_index, factor) = equdist.upper_border(value);
-    ///     let min = equdist.gen(min_index);
-    ///     let max = equdist.gen(max_index);
+    ///     let min = equdist.interpolate(min_index);
+    ///     let max = equdist.interpolate(max_index);
     ///     assert_f64_near!(utils::lerp(min,max,factor),value);
     /// }
     /// ```
@@ -578,7 +578,7 @@ where
     R: Real + FromPrimitive,
 {
     type Output = R;
-    fn gen(&self, input: usize) -> R {
+    fn interpolate(&self, input: usize) -> R {
         R::from_usize(input).unwrap() / R::from_usize(N - 1).unwrap()
     }
 }
@@ -648,7 +648,7 @@ where
         Self::Output: PartialOrd + Copy,
     {
         // extrapolation to the left
-        if element < self.gen(min) {
+        if element < self.interpolate(min) {
             return min;
         }
         let scaled = element * R::from_usize(N - 1).unwrap();
@@ -688,8 +688,8 @@ where
     /// let values = vec![-1.0,0.0,0.15,0.6,1.0,20.0];
     /// for value in values {
     ///     let (min_index, max_index, factor) = equdist.upper_border(value);
-    ///     let min = equdist.gen(min_index);
-    ///     let max = equdist.gen(max_index);
+    ///     let min = equdist.interpolate(min_index);
+    ///     let max = equdist.interpolate(max_index);
     ///     assert_f64_near!(utils::lerp(min,max,factor),value);
     /// }
     /// ```

--- a/src/base/mod.rs
+++ b/src/base/mod.rs
@@ -21,7 +21,7 @@ pub use space::{ConstSpace, Space};
 #[cfg(feature = "std")]
 impl<T: Copy> Generator<usize> for Vec<T> {
     type Output = T;
-    fn gen(&self, input: usize) -> Self::Output {
+    fn interpolate(&self, input: usize) -> Self::Output {
         self[input]
     }
 }
@@ -45,7 +45,7 @@ impl<T: Copy> DiscreteGenerator for Vec<T> {
 
 impl<T: Copy> Generator<usize> for &[T] {
     type Output = T;
-    fn gen(&self, input: usize) -> Self::Output {
+    fn interpolate(&self, input: usize) -> Self::Output {
         self[input]
     }
 }
@@ -58,7 +58,7 @@ impl<T: Copy> DiscreteGenerator for &[T] {
 
 impl<T: Copy, const N: usize> Generator<usize> for [T; N] {
     type Output = T;
-    fn gen(&self, input: usize) -> Self::Output {
+    fn interpolate(&self, input: usize) -> Self::Output {
         self[input]
     }
 }

--- a/src/base/mod.rs
+++ b/src/base/mod.rs
@@ -8,7 +8,7 @@ mod space;
 pub use adaptors::{Clamp, Composite, Repeat, Slice, Stack, TransformInput, Wrap};
 #[allow(unreachable_pub)]
 pub use generator::{
-    ConstDiscreteGenerator, Curve, DiscreteGenerator, Extract, Generator, Stepper, Take,
+    ConstDiscreteGenerator, Curve, DiscreteGenerator, Extract, Generator, Stepper,
 };
 #[allow(unreachable_pub)]
 pub use list::{ConstEquidistant, Equidistant, NotSorted, Sorted, SortedGenerator};

--- a/src/bezier/mod.rs
+++ b/src/bezier/mod.rs
@@ -223,7 +223,7 @@ where
             .enumerate()
             .take(self.elements.len())
         {
-            *val = self.elements.gen(i);
+            *val = self.elements.interpolate(i);
         }
         workspace
     }
@@ -237,7 +237,7 @@ where
     R: Real,
 {
     type Output = E::Output;
-    fn gen(&self, scalar: R) -> E::Output {
+    fn interpolate(&self, scalar: R) -> E::Output {
         // we pass only slices to guarantee the size of workspace to match the number of elements
         bezier(
             &mut self.workspace().as_mut()[..self.elements.len()],
@@ -337,8 +337,8 @@ mod test {
             .constant()
             .build()
             .unwrap();
-        assert_f64_near!(bez.gen(2.0), 820.0);
-        assert_f64_near!(bez.gen(-1.0), 280.0);
+        assert_f64_near!(bez.interpolate(2.0), 820.0);
+        assert_f64_near!(bez.interpolate(-1.0), 280.0);
     }
 
     #[test]

--- a/src/bspline/adaptors.rs
+++ b/src/bspline/adaptors.rs
@@ -44,9 +44,9 @@ where
     G: DiscreteGenerator,
 {
     type Output = G::Output;
-    fn gen(&self, input: usize) -> Self::Output {
+    fn interpolate(&self, input: usize) -> Self::Output {
         let clamped = input.max(self.n).min(self.inner.len() + self.n - 1);
-        self.inner.gen(clamped - self.n)
+        self.inner.interpolate(clamped - self.n)
     }
 }
 
@@ -113,8 +113,8 @@ where
     G: DiscreteGenerator,
 {
     type Output = G::Output;
-    fn gen(&self, input: usize) -> Self::Output {
-        self.inner.gen(input + 1)
+    fn interpolate(&self, input: usize) -> Self::Output {
+        self.inner.interpolate(input + 1)
     }
 }
 

--- a/src/bspline/mod.rs
+++ b/src/bspline/mod.rs
@@ -127,7 +127,7 @@ where
         let mut workspace = self.space.workspace();
         let mut_workspace = workspace.as_mut();
         for (i, val) in mut_workspace.iter_mut().enumerate().take(self.degree + 1) {
-            *val = self.elements.gen(index - self.degree + i);
+            *val = self.elements.interpolate(index - self.degree + i);
         }
         workspace
     }
@@ -142,7 +142,7 @@ where
     K: SortedGenerator<Output = R>,
 {
     type Output = E::Output;
-    fn gen(&self, scalar: R) -> E::Output {
+    fn interpolate(&self, scalar: R) -> E::Output {
         // we do NOT calculaute a possible multiplicity of the scalar, as we assume
         // the chance of hitting a knot is almost zero.
         let lower_cut = self.degree;
@@ -160,8 +160,8 @@ where
         for r in 1..=self.degree {
             for j in 0..=(self.degree - r) {
                 let i = j + r + index - self.degree;
-                let factor = (scalar - self.knots.gen(i - 1))
-                    / (self.knots.gen(i + self.degree - r) - self.knots.gen(i - 1));
+                let factor = (scalar - self.knots.interpolate(i - 1))
+                    / (self.knots.interpolate(i + self.degree - r) - self.knots.interpolate(i - 1));
                 elements[j] = elements[j].merge(elements[j + 1], factor);
             }
         }
@@ -179,8 +179,8 @@ where
 {
     fn domain(&self) -> [R; 2] {
         [
-            self.knots.gen(self.degree - 1),
-            self.knots.gen(self.knots.len() - self.degree),
+            self.knots.interpolate(self.degree - 1),
+            self.knots.interpolate(self.knots.len() - self.degree),
         ]
     }
 }
@@ -286,7 +286,7 @@ mod test {
             .build()
             .unwrap();
         for i in 0..expect.len() {
-            assert_f32_near!(spline.gen(expect[i].0), expect[i].1);
+            assert_f32_near!(spline.interpolate(expect[i].0), expect[i].1);
         }
     }
 
@@ -312,7 +312,7 @@ mod test {
             .build()
             .unwrap();
         for i in 0..expect.len() {
-            assert_f32_near!(spline.gen(expect[i].0), expect[i].1);
+            assert_f32_near!(spline.interpolate(expect[i].0), expect[i].1);
         }
     }
 
@@ -337,7 +337,7 @@ mod test {
             .build()
             .unwrap();
         for i in 0..expect.len() {
-            assert_f32_near!(spline.gen(expect[i].0), expect[i].1);
+            assert_f32_near!(spline.interpolate(expect[i].0), expect[i].1);
         }
     }
 
@@ -365,7 +365,7 @@ mod test {
             .build()
             .unwrap();
         for i in 0..expect.len() {
-            assert_f32_near!(spline.gen(expect[i].0), expect[i].1);
+            assert_f32_near!(spline.interpolate(expect[i].0), expect[i].1);
         }
     }
 
@@ -393,7 +393,7 @@ mod test {
             .build()
             .unwrap();
         for i in 0..expect.len() {
-            assert_f64_near!(spline.gen(expect[i].0), expect[i].1);
+            assert_f64_near!(spline.interpolate(expect[i].0), expect[i].1);
         }
     }
 

--- a/src/easing/mod.rs
+++ b/src/easing/mod.rs
@@ -31,7 +31,7 @@ where
     F: Fn(R) -> R,
 {
     type Output = R;
-    fn gen(&self, input: R) -> R {
+    fn interpolate(&self, input: R) -> R {
         (self.func)(input)
     }
 }
@@ -66,7 +66,7 @@ impl Default for Identity {
 
 impl<R> Generator<R> for Identity {
     type Output = R;
-    fn gen(&self, input: R) -> R {
+    fn interpolate(&self, input: R) -> R {
         input
     }
 }

--- a/src/easing/plateau.rs
+++ b/src/easing/plateau.rs
@@ -52,7 +52,7 @@ where
     R: Real + FromPrimitive,
 {
     type Output = R;
-    fn gen(&self, input: R) -> R {
+    fn interpolate(&self, input: R) -> R {
         smoothstep(over_clamp(input, self.min, self.max))
     }
 }

--- a/src/linear/mod.rs
+++ b/src/linear/mod.rs
@@ -119,12 +119,12 @@ where
     /// # Panics
     ///
     /// Panics if `scalar` is NaN or similar.
-    fn gen(&self, scalar: K::Output) -> Self::Output {
+    fn interpolate(&self, scalar: K::Output) -> Self::Output {
         //we use upper_border_with_factor as this allows us a performance improvement for equidistant knots
         let (min_index, max_index, factor) = self.knots.upper_border(scalar);
-        let min_point = self.elements.gen(min_index);
-        let max_point = self.elements.gen(max_index);
-        min_point.merge(max_point, self.easing.gen(factor))
+        let min_point = self.elements.interpolate(min_index);
+        let max_point = self.elements.interpolate(max_index);
+        min_point.merge(max_point, self.easing.interpolate(factor))
     }
 }
 
@@ -261,10 +261,10 @@ mod test {
             .knots([1.0, 2.0, 3.0, 4.0])
             .build()
             .unwrap();
-        assert_f64_near!(lin.gen(1.5), 60.0);
-        assert_f64_near!(lin.gen(2.5), 50.0);
-        assert_f64_near!(lin.gen(-1.0), -140.0);
-        assert_f64_near!(lin.gen(5.0), 400.0);
+        assert_f64_near!(lin.interpolate(1.5), 60.0);
+        assert_f64_near!(lin.interpolate(2.5), 50.0);
+        assert_f64_near!(lin.interpolate(-1.0), -140.0);
+        assert_f64_near!(lin.interpolate(5.0), 400.0);
     }
 
     #[test]
@@ -275,7 +275,7 @@ mod test {
             .normalized()
             .build()
             .unwrap();
-        assert_f64_near!(lin.gen(0.5), 0.1);
+        assert_f64_near!(lin.interpolate(0.5), 0.1);
         // const LIN : Linear<f64,f64,ConstEquidistant<f64>,CollectionWrapper<[f64;4],f64>> = Linear::new_equidistant_unchecked([20.0,100.0,0.0,200.0]);
     }
 

--- a/src/weights/mod.rs
+++ b/src/weights/mod.rs
@@ -35,8 +35,8 @@ where
 {
     type Output =
         Homogeneous<<G::Output as IntoWeight>::Element, <G::Output as IntoWeight>::Weight>;
-    fn gen(&self, input: Input) -> Self::Output {
-        self.gen.gen(input).into_weight()
+    fn interpolate(&self, input: Input) -> Self::Output {
+        self.gen.interpolate(input).into_weight()
     }
 }
 

--- a/src/weights/weighted.rs
+++ b/src/weights/weighted.rs
@@ -31,8 +31,8 @@ where
     G::Output: Project,
 {
     type Output = <G::Output as Project>::Element;
-    fn gen(&self, input: I) -> Self::Output {
-        self.inner.gen(input).project()
+    fn interpolate(&self, input: I) -> Self::Output {
+        self.inner.interpolate(input).project()
     }
 }
 


### PR DESCRIPTION
Closes #31 

Hi @NicolasKlenert,

Firstly thank you for the `enterpolate` library. I've used it for many years.

This PR suggests renaming the `Generator::gen` method to `Generator::interpolate` due to `gen` becoming a reserved keyword in the 2024 edition of Rust. ([RFC #3513](https://rust-lang.github.io/rfcs/3513-gen-blocks.html)).

I appreciate this may be a controversial suggestion, so of course no problem if it is not accepted or if you'd like me to refactor to a method name of your choice.

I've also removed some of the unused imports caught by clippy.
All tests pass, and using `enterpolate` as an upstream dependency in a Rust2024 project no longer emits warnings asking `.gen` to be renamed to `.r#gen`.

I have not renamed any of the internal `gen` variables, as these are not exposed by the API.

I investigated upgrading `enterpolate` itself to the 2024 standard:
1. Type inference failures in struct definitions and function calls - seems like a simple syntax change
2. Missing type annotations in generic structs and methods - again, a syntax change
3. Issues with #[derive(Clone)] on types with generic parameters - I did not feel confident enough in understanding the ramification of code changes here to justify including the changes in this PR

Thanks again for your work and time maintaining this excellent library.
Best, Freddy


Ps:

Perhaps implementing `gen` and `evaluate` directly on `Linear` etc. as convenience methods would reduce the verbosity of calling `gen` in some cicrcumstances:

```rust
Sorted<Vec<T>>, Vec<C>, Identity> as Generator<T>>::r#gen(g, t)
```

However, it's more likely I'm misunderstanding something with how to use the library!