### PR TITLE
Update to Rust Edition 2024

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,13 +8,12 @@ license = "MIT OR Apache-2.0"
 documentation = "https://docs.rs/enterpolation"
 repository = "https://github.com/NicolasKlenert/enterpolation"
 readme = "README.md"
-keywords = ["interpolation", "curve", "spline", "bspline", "bezier"]
+keywords = ["interpolation", "curve", "spline", "bspline", "bezier", "nurbs"]
 categories = ["graphics", "mathematics", "no-std"]
 version = "0.3.0"
 
 [dependencies]
 topology-traits = { version = "0.1.2", default-features = false }
-assert_float_eq = { version = "1.1.4", default-features = false }
 num-traits = { version = "0.2.19", default-features = false }
 serde = { version = "1.0.219", optional = true, default-features = false, features = [
     "derive",
@@ -22,6 +21,7 @@ serde = { version = "1.0.219", optional = true, default-features = false, featur
 
 
 [dev-dependencies]
+assert_float_eq = { version = "1.1.4", default-features = false }
 # real black box in necessary for accurate benches, but is only available in rust-nightly
 criterion = { version = "0.5" } #, features = ["real_blackbox"]}
 # we are using palette and image as dependency for our gradient example

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,13 +10,13 @@ repository = "https://github.com/NicolasKlenert/enterpolation"
 readme = "README.md"
 keywords = ["interpolation", "curve", "spline", "bspline", "bezier"]
 categories = ["graphics", "mathematics", "no-std"]
-version = "0.2.1"
+version = "0.3.0"
 
 [dependencies]
 topology-traits = { version = "0.1.2", default-features = false }
-assert_float_eq = { version = "1", default-features = false }
-num-traits = { version = "0.2", default-features = false }
-serde = { version = "1", optional = true, default-features = false, features = [
+assert_float_eq = { version = "1.1.4", default-features = false }
+num-traits = { version = "0.2.19", default-features = false }
+serde = { version = "1.0.219", optional = true, default-features = false, features = [
     "derive",
 ] }
 
@@ -25,8 +25,8 @@ serde = { version = "1", optional = true, default-features = false, features = [
 # real black box in necessary for accurate benches, but is only available in rust-nightly
 criterion = { version = "0.5" } #, features = ["real_blackbox"]}
 # we are using palette and image as dependency for our gradient example
-palette = "0.7"
-image = "0.24"
+palette = "0.7.6"
+image = "0.25.6"
 
 [features]
 default = ["std", "linear", "bezier", "bspline"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "enterpolation"
 authors = ["Nicolas Klenert <klenert.nicolas@gmail.com>"]
 exclude = ["examples/*", ".gitignore", "CHANGELOG.md", "CONTRIBUTING.md"]
-edition = "2021"
+edition = "2024"
 description = "A library for creating and computing interpolations, extrapolations and smoothing of generic data points."
 license = "MIT OR Apache-2.0"
 documentation = "https://docs.rs/enterpolation"
@@ -13,22 +13,29 @@ categories = ["graphics", "mathematics", "no-std"]
 version = "0.2.1"
 
 [dependencies]
-topology-traits = {version="0.1.2", default-features=false}
-assert_float_eq = {version="1", default-features=false}
-num-traits = {version="0.2", default-features=false}
-serde = { version = "1", optional = true, default-features=false, features = ["derive"] }
+topology-traits = { version = "0.1.2", default-features = false }
+assert_float_eq = { version = "1", default-features = false }
+num-traits = { version = "0.2", default-features = false }
+serde = { version = "1", optional = true, default-features = false, features = [
+    "derive",
+] }
 
 
 [dev-dependencies]
 # real black box in necessary for accurate benches, but is only available in rust-nightly
-criterion = {version = "0.5"}#, features = ["real_blackbox"]}
+criterion = { version = "0.5" } #, features = ["real_blackbox"]}
 # we are using palette and image as dependency for our gradient example
 palette = "0.7"
 image = "0.24"
 
 [features]
-default = ["std","linear","bezier","bspline"]
-std = ["num-traits/std", "assert_float_eq/std", "topology-traits/std", "serde?/std"]
+default = ["std", "linear", "bezier", "bspline"]
+std = [
+    "num-traits/std",
+    "assert_float_eq/std",
+    "topology-traits/std",
+    "serde?/std",
+]
 libm = ["num-traits/libm", "topology-traits/libm"]
 linear = []
 bezier = []
@@ -42,7 +49,7 @@ harness = false
 [[example]]
 name = "bspline_reasoning"
 path = "examples/bspline_reasoning.rs"
-required-features = ["linear","bezier","bspline"]
+required-features = ["linear", "bezier", "bspline"]
 
 [[example]]
 name = "gradient"
@@ -52,7 +59,7 @@ required-features = ["bspline"]
 [[example]]
 name = "linear"
 path = "examples/linear.rs"
-required-features = ["std","linear"]
+required-features = ["std", "linear"]
 
 [[example]]
 name = "noise"
@@ -75,9 +82,7 @@ status = "actively-developed"
 [package.metadata.cargo-all-features]
 
 # Skip std and libm, as they are incompatible.
-skip_feature_sets = [
-    ["std", "libm"],
-]
+skip_feature_sets = [["std", "libm"]]
 # Always include either std or libm
 always_include_features = [["std", "libm"]]
 

--- a/README.md
+++ b/README.md
@@ -81,10 +81,10 @@ fn main() -> Result<(), BSplineError> {
 }
 ```
 
-For further information how to use any curve, one may look at the main traits of this crate: [`Generator`] and [`Curve`].
+For further information how to use any curve, one may look at the main traits of this crate: [`Signal`] and [`Curve`].
 
-[`Generator`]: https://docs.rs/enterpolation/0.1.0/enterpolation/trait.Generator.html
-[`Curve`]: https://docs.rs/enterpolation/0.1.0/enterpolation/trait.Curve.html
+[`Signal`]: https://docs.rs/enterpolation/0.3.0/enterpolation/trait.Signal.html
+[`Curve`]: https://docs.rs/enterpolation/0.3.0/enterpolation/trait.Curve.html
 
 ### Further Examples
 
@@ -99,7 +99,7 @@ This crate comes with a feature for every different interpolation method, such a
 If one wants to only enable specific crate features, they have to use the following `Cargo.toml` dependency configuration:
 ```toml
 [dependencies.enterpolation]
-version = "0.2"
+version = "0.3"
 default-features = false
 # re-enable all wanted features
 features = ["linear"]
@@ -144,22 +144,22 @@ If the elements you want to interpolate already implement [addition] with themse
 
 Otherwise this crate re-exports a trait [Merge], which represents the capability of an element to be merged with another one. This trait is necessary for all interpolations. Furthermore the core [Default] trait is also necessary for bezier curves and B-splines.
 
-Elements can be given to the curve with an array, a vector or by implementing the [DiscreteGenerator] trait. Basically every collection with an indexing operation can implement this trait. However generators can also implement it. Such one may generate the elements which should be interpolated on-the-fly. This can reduce the memory footprint if elements can be generically generated and one wants to interpolate many elements.
+Elements can be given to the curve with an array, a vector or by implementing the [Chain] trait. Basically every collection with an indexing operation can implement this trait. However signals can also implement it. Such one may generate the elements which should be interpolated on-the-fly. This can reduce the memory footprint if elements can be generically generated and one wants to interpolate many elements.
 
 [addition]: https://doc.rust-lang.org/core/ops/trait.Add.html
 [multiplication]: https://doc.rust-lang.org/core/ops/trait.Mul.html
 [Merge]: https://docs.rs/topology-traits/0.1.1/topology_traits/trait.Merge.html
 [Default]: https://doc.rust-lang.org/beta/core/default/trait.Default.html
-[DiscreteGenerator]: https://docs.rs/enterpolation/0.1.0/enterpolation/trait.DiscreteGenerator.html
+[Chain]: https://docs.rs/enterpolation/0.3.0/enterpolation/trait.Chain.html
 
 #### Requirements for Knots
 
 Knots represent the location of the elements in the input space. Such knots are usually of the same type as your input for the interpolation itself. As all interpolations (yet) are curves, usually knots are `f32` or `f64`. Elements must be multipliable with knots and knots have to be sorted with the smallest knot at index zero.
 
-Knots also can be given via an array or a vector, or some other type which implements the [`DiscreteGenerator`] trait. One may also implement the [`SortedGenerator`] trait if the type is always guaranteed to represent sorted knots.
+Knots also can be given via an array or a vector, or some other type which implements the [`Chain`] trait. One may also implement the [`SortedChain`] trait if the type is always guaranteed to represent sorted knots.
 
-[`DiscreteGenerator`]: https://docs.rs/enterpolation/0.1.0/enterpolation/trait.DiscreteGenerator.html
-[`SortedGenerator`]: https://docs.rs/enterpolation/0.1.0/enterpolation/trait.SortedGenerator.html
+[`Chain`]: https://docs.rs/enterpolation/0.3.0/enterpolation/trait.Chain.html
+[`SortedChain`]: https://docs.rs/enterpolation/0.3.0/enterpolation/trait.SortedChain.html
 
 #### B-spline Peculiarity
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Enterpolation is a library to generate and use different interpolation and extra
 Add this to your `Cargo.toml`:
 ```toml
 [dependencies]
-enterpolation = "0.2"
+enterpolation = "0.3"
 ```
 
 Here is a simple example creating a linear interpolation of `f64` and extracting 21 values from start to end. This library supports all elements which can be added together and multiplied with a scalar (in our case also `f64`). Instead of interpolating floats, one could interpolate coordinates, rotations, transformations, velocities, geometries, sound, colors and so on.
@@ -82,9 +82,6 @@ fn main() -> Result<(), BSplineError> {
 ```
 
 For further information how to use any curve, one may look at the main traits of this crate: [`Signal`] and [`Curve`].
-
-[`Signal`]: https://docs.rs/enterpolation/0.3.0/enterpolation/trait.Signal.html
-[`Curve`]: https://docs.rs/enterpolation/0.3.0/enterpolation/trait.Curve.html
 
 ### Further Examples
 
@@ -150,16 +147,12 @@ Elements can be given to the curve with an array, a vector or by implementing th
 [multiplication]: https://doc.rust-lang.org/core/ops/trait.Mul.html
 [Merge]: https://docs.rs/topology-traits/0.1.1/topology_traits/trait.Merge.html
 [Default]: https://doc.rust-lang.org/beta/core/default/trait.Default.html
-[Chain]: https://docs.rs/enterpolation/0.3.0/enterpolation/trait.Chain.html
 
 #### Requirements for Knots
 
 Knots represent the location of the elements in the input space. Such knots are usually of the same type as your input for the interpolation itself. As all interpolations (yet) are curves, usually knots are `f32` or `f64`. Elements must be multipliable with knots and knots have to be sorted with the smallest knot at index zero.
 
 Knots also can be given via an array or a vector, or some other type which implements the [`Chain`] trait. One may also implement the [`SortedChain`] trait if the type is always guaranteed to represent sorted knots.
-
-[`Chain`]: https://docs.rs/enterpolation/0.3.0/enterpolation/trait.Chain.html
-[`SortedChain`]: https://docs.rs/enterpolation/0.3.0/enterpolation/trait.SortedChain.html
 
 #### B-spline Peculiarity
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,0 +1,14 @@
+Version 0.3 (2025-05-08)
+=======================
+
+Breaking Changes
+----------------
+- Renamed `Generator::gen()` to `Signal::eval()`
+- Renamed `DiscreteGenerator` to `Chain`
+- Renamed `ConstDiscreteGenerator` to `ConstChain`
+- Renamed `SortedGenerator` to `SortedChain`
+
+Other Changes
+-------------
+- Updated crate to Rust Edition 2024
+- Updated dependencies

--- a/benches/benches.rs
+++ b/benches/benches.rs
@@ -1,6 +1,6 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use enterpolation::bspline::BSpline;
-use enterpolation::{Curve, Generator};
+use enterpolation::{Curve, Signal};
 
 const ELEMENTS: [f64; 100] = [
     943.0, 978.0, 579.0, 15.0, 608.0, 938.0, 669.0, 98.0, 720.0, 303.0, 345.0, 421.0, 767.0, 798.0,

--- a/benches/benches.rs
+++ b/benches/benches.rs
@@ -1,4 +1,4 @@
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use criterion::{Criterion, black_box, criterion_group, criterion_main};
 use enterpolation::bspline::BSpline;
 use enterpolation::{Curve, Signal};
 

--- a/examples/bspline_reasoning.rs
+++ b/examples/bspline_reasoning.rs
@@ -1,7 +1,8 @@
 //! This example shall illustrate bsplines and how to corrolate to other curves.
 
-use assert_float_eq::assert_f64_near;
 use enterpolation::{bezier::Bezier, bspline::BSpline, linear::Linear, Curve};
+#[macro_use]
+extern crate assert_float_eq;
 
 fn main() {
     // ---- LINEAR -----

--- a/examples/bspline_reasoning.rs
+++ b/examples/bspline_reasoning.rs
@@ -1,6 +1,6 @@
 //! This example shall illustrate bsplines and how to corrolate to other curves.
 
-use enterpolation::{bezier::Bezier, bspline::BSpline, linear::Linear, Curve};
+use enterpolation::{Curve, bezier::Bezier, bspline::BSpline, linear::Linear};
 #[macro_use]
 extern crate assert_float_eq;
 

--- a/examples/bspline_reasoning.rs
+++ b/examples/bspline_reasoning.rs
@@ -1,6 +1,6 @@
 //! This example shall illustrate bsplines and how to corrolate to other curves.
 
-use assert_float_eq::{afe_is_f64_near, afe_near_error_msg, assert_f64_near};
+use assert_float_eq::assert_f64_near;
 use enterpolation::{bezier::Bezier, bspline::BSpline, linear::Linear, Curve};
 
 fn main() {

--- a/examples/gradient.rs
+++ b/examples/gradient.rs
@@ -1,4 +1,4 @@
-use enterpolation::{bspline::BSpline, Curve, Generator, Merge};
+use enterpolation::{Curve, Merge, Signal, bspline::BSpline};
 use image::{ImageBuffer, Rgba};
 use palette::{Hsl, IntoColor, Mix};
 

--- a/examples/gradient.rs
+++ b/examples/gradient.rs
@@ -48,7 +48,9 @@ fn main() {
     let mut imgbuf = ImageBuffer::new(width, height);
 
     for (x, _, pixel) in imgbuf.enumerate_pixels_mut() {
-        let hsl = spline.gen(remap(x as f32, 0.0, width as f32, dmin, dmax)).0;
+        let hsl = spline
+            .eval(remap(x as f32, 0.0, width as f32, dmin, dmax))
+            .0;
         let srgb: palette::Srgb = hsl.into_color();
         let raw: (u8, u8, u8) = srgb.into_format().into_components();
         *pixel = Rgba([raw.0, raw.1, raw.2, 255]);

--- a/examples/linear.rs
+++ b/examples/linear.rs
@@ -1,5 +1,5 @@
-use enterpolation::linear::Linear;
 use enterpolation::Signal;
+use enterpolation::linear::Linear;
 
 /// This mimics R's approx function
 /// ```R

--- a/examples/linear.rs
+++ b/examples/linear.rs
@@ -1,5 +1,5 @@
 use enterpolation::linear::Linear;
-use enterpolation::Generator;
+use enterpolation::Signal;
 
 /// This mimics R's approx function
 /// ```R

--- a/examples/noise.rs
+++ b/examples/noise.rs
@@ -13,7 +13,7 @@ struct ValueGenerator {}
 
 impl Generator<usize> for ValueGenerator {
     type Output = f64;
-    fn gen(&self, input: usize) -> f64 {
+    fn eval(&self, input: usize) -> f64 {
         // In Reality we would want to use a hash-like function
         // otherwise we don't create noise but a simple pattern
         (input % 10) as f64
@@ -45,7 +45,7 @@ fn main() {
     // lands on an integer we know that values at x and x+10.0 are equal.
     let samples = [3.3, 157.23, 989.98];
     for sample in samples.iter() {
-        assert_f64_near!(spline.gen(sample), spline.gen(sample + 10.0), 10);
+        assert_f64_near!(spline.eval(sample), spline.eval(sample + 10.0), 10);
     }
     println!("Nearly infinite long curve generated!");
 }

--- a/examples/noise.rs
+++ b/examples/noise.rs
@@ -3,8 +3,10 @@
 //! Enterpolation is written to be as generic as possible and using a generator
 //! instead of a collection allows to define a (nearly) infinite detail-rich interpolation.
 
-use assert_float_eq::assert_f64_near;
 use enterpolation::{bspline::BSpline, DiscreteGenerator, Generator};
+
+#[macro_use]
+extern crate assert_float_eq;
 
 // We define our own value generator which will be the basis of our (nearly) infinite curve.
 struct ValueGenerator {}

--- a/examples/noise.rs
+++ b/examples/noise.rs
@@ -3,7 +3,7 @@
 //! Enterpolation is written to be as generic as possible and using a generator
 //! instead of a collection allows to define a (nearly) infinite detail-rich interpolation.
 
-use assert_float_eq::{afe_is_f64_near, afe_near_error_msg, assert_f64_near};
+use assert_float_eq::assert_f64_near;
 use enterpolation::{bspline::BSpline, DiscreteGenerator, Generator};
 
 // We define our own value generator which will be the basis of our (nearly) infinite curve.

--- a/examples/noise.rs
+++ b/examples/noise.rs
@@ -1,17 +1,17 @@
-//! This examples show how to use a generator instead of a collection
+//! This examples show how to use a signal instead of a collection
 //!
-//! Enterpolation is written to be as generic as possible and using a generator
+//! Enterpolation is written to be as generic as possible and using a signal
 //! instead of a collection allows to define a (nearly) infinite detail-rich interpolation.
 
-use enterpolation::{bspline::BSpline, DiscreteGenerator, Generator};
+use enterpolation::{Chain, Signal, bspline::BSpline};
 
 #[macro_use]
 extern crate assert_float_eq;
 
-// We define our own value generator which will be the basis of our (nearly) infinite curve.
-struct ValueGenerator {}
+// We define our own value signal which will be the basis of our (nearly) infinite curve.
+struct ValueSignal {}
 
-impl Generator<usize> for ValueGenerator {
+impl Signal<usize> for ValueSignal {
     type Output = f64;
     fn eval(&self, input: usize) -> f64 {
         // In Reality we would want to use a hash-like function
@@ -20,7 +20,7 @@ impl Generator<usize> for ValueGenerator {
     }
 }
 
-impl DiscreteGenerator for ValueGenerator {
+impl Chain for ValueSignal {
     // We can generator for any value of usize, however, we only want to use 10,000 values
     fn len(&self) -> usize {
         // Values near usize::MAX may force the spline to panic as a spline needs more knots than elements
@@ -31,9 +31,9 @@ impl DiscreteGenerator for ValueGenerator {
 fn main() {
     let spline = BSpline::builder()
         .clamped()
-        .elements(ValueGenerator {})
+        .elements(ValueSignal {})
         // we use equidistant as we don't want to save that many knots in a collection
-        // as alternative one could also define a KnotGenerator
+        // as alternative one could also define a KnotSignal
         .equidistant()
         .degree(3)
         // We want each knot to lie on an integer.
@@ -41,7 +41,7 @@ fn main() {
         .constant::<4>()
         .build()
         .expect("As the curve is hardcoded, this should always work");
-    // As our ValueGenerator is so boring and we constructed the domain such that every knot
+    // As our ValueSignal is so boring and we constructed the domain such that every knot
     // lands on an integer we know that values at x and x+10.0 are equal.
     let samples = [3.3, 157.23, 989.98];
     for sample in samples.iter() {

--- a/examples/nurbs.rs
+++ b/examples/nurbs.rs
@@ -6,7 +6,7 @@
 
 use core::f64::consts::PI;
 use core::ops::{Add, Div, Mul, Sub};
-use enterpolation::{bspline::BSpline, Curve, Generator};
+use enterpolation::{Curve, Signal, bspline::BSpline};
 // used to test equality of f64s
 #[macro_use]
 extern crate assert_float_eq;

--- a/examples/nurbs.rs
+++ b/examples/nurbs.rs
@@ -9,8 +9,8 @@ use core::ops::{Add, Div, Mul, Sub};
 use enterpolation::{bspline::BSpline, Curve, Generator};
 // used to test equality of f64s
 use assert_float_eq::{
-    afe_abs, afe_absolute_error_msg, afe_is_absolute_eq, afe_is_f64_near, afe_near_error_msg,
-    assert_f64_near, assert_float_absolute_eq,
+    afe_abs, afe_is_absolute_eq, afe_is_f64_near, afe_near_error_msg, assert_f64_near,
+    assert_float_absolute_eq,
 };
 
 /// We create our own 2D Point

--- a/examples/nurbs.rs
+++ b/examples/nurbs.rs
@@ -8,7 +8,8 @@ use core::f64::consts::PI;
 use core::ops::{Add, Div, Mul, Sub};
 use enterpolation::{bspline::BSpline, Curve, Generator};
 // used to test equality of f64s
-use assert_float_eq::{assert_f64_near, assert_float_absolute_eq};
+#[macro_use]
+extern crate assert_float_eq;
 
 /// We create our own 2D Point
 #[derive(Debug, Copy, Clone)]

--- a/examples/nurbs.rs
+++ b/examples/nurbs.rs
@@ -114,7 +114,7 @@ fn main() {
     for val in [0.0f64, 1.0, 2.0, 3.0, 4.0].iter().copied() {
         // scale value to the corresponding circumference
         let circle_point = Point::new((val * 0.5 * PI).cos(), (val * 0.5 * PI).sin());
-        assert_float_absolute_eq!(nurbs.gen(val).dist(circle_point), 0.0);
+        assert_float_absolute_eq!(nurbs.eval(val).dist(circle_point), 0.0);
     }
     println!("Successful creation of unit circle with a NURBS!");
     // but we can approximate it by linearizing.

--- a/examples/nurbs.rs
+++ b/examples/nurbs.rs
@@ -8,10 +8,7 @@ use core::f64::consts::PI;
 use core::ops::{Add, Div, Mul, Sub};
 use enterpolation::{bspline::BSpline, Curve, Generator};
 // used to test equality of f64s
-use assert_float_eq::{
-    afe_abs, afe_is_absolute_eq, afe_is_f64_near, afe_near_error_msg, assert_f64_near,
-    assert_float_absolute_eq,
-};
+use assert_float_eq::{assert_f64_near, assert_float_absolute_eq};
 
 /// We create our own 2D Point
 #[derive(Debug, Copy, Clone)]

--- a/examples/plateaus.rs
+++ b/examples/plateaus.rs
@@ -1,6 +1,6 @@
 //! First we show why the easing function `plateau` is called that way. Afterwards we use it
 //! to generate a color gradient to categorise values neatly.
-use enterpolation::{easing::Plateau, linear::Linear, Curve, Generator, Merge};
+use enterpolation::{easing::Plateau, linear::Linear, Curve, Signal, Merge};
 use image::{ImageBuffer, Rgba};
 use palette::{Hsl, IntoColor, Mix};
 

--- a/examples/plateaus.rs
+++ b/examples/plateaus.rs
@@ -1,6 +1,6 @@
 //! First we show why the easing function `plateau` is called that way. Afterwards we use it
 //! to generate a color gradient to categorise values neatly.
-use enterpolation::{easing::Plateau, linear::Linear, Curve, Signal, Merge};
+use enterpolation::{Curve, Merge, Signal, easing::Plateau, linear::Linear};
 use image::{ImageBuffer, Rgba};
 use palette::{Hsl, IntoColor, Mix};
 

--- a/examples/plateaus.rs
+++ b/examples/plateaus.rs
@@ -74,10 +74,10 @@ fn main() {
     for (x, y, pixel) in imgbuf.enumerate_pixels_mut() {
         let raw = if y <= upper_height {
             gradient
-                .gen(remap(x as f32, 0.0, width as f32, dmin, dmax))
+                .eval(remap(x as f32, 0.0, width as f32, dmin, dmax))
                 .get_raw()
         } else {
-            let graph = lin.gen(remap(x as f32, 0.0, width as f32, dmin, dmax));
+            let graph = lin.eval(remap(x as f32, 0.0, width as f32, dmin, dmax));
             let graph = remap(graph, omin, omax, 0.0, 1.0);
             // test if pixel falls into the area of the graph
             if (graph
@@ -94,7 +94,7 @@ fn main() {
                 [0, 0, 0]
             } else {
                 plateaus
-                    .gen(remap(x as f32, 0.0, width as f32, dmin, dmax))
+                    .eval(remap(x as f32, 0.0, width as f32, dmin, dmax))
                     .get_raw()
             }
         };

--- a/src/base/adaptors.rs
+++ b/src/base/adaptors.rs
@@ -26,10 +26,10 @@ where
     R: Real,
 {
     type Output = G::Output;
-    fn gen(&self, input: R) -> Self::Output {
+    fn eval(&self, input: R) -> Self::Output {
         let [min, max] = self.domain();
         let clamped = clamp(input, min, max);
-        self.0.gen(clamped)
+        self.0.eval(clamped)
     }
 }
 
@@ -86,8 +86,8 @@ where
     R: Real,
 {
     type Output = G::Output;
-    fn gen(&self, input: R) -> Self::Output {
-        self.0.gen(input)
+    fn eval(&self, input: R) -> Self::Output {
+        self.0.eval(input)
     }
 }
 
@@ -144,8 +144,8 @@ where
     G: Generator<<<I as Mul<M>>::Output as Add<A>>::Output>,
 {
     type Output = G::Output;
-    fn gen(&self, input: I) -> Self::Output {
-        self.inner.gen(input * self.multiplication + self.addition)
+    fn eval(&self, input: I) -> Self::Output {
+        self.inner.eval(input * self.multiplication + self.addition)
     }
 }
 
@@ -182,8 +182,8 @@ where
     B: Generator<A::Output>,
 {
     type Output = B::Output;
-    fn gen(&self, scalar: T) -> Self::Output {
-        self.1.gen(self.0.gen(scalar))
+    fn eval(&self, scalar: T) -> Self::Output {
+        self.1.eval(self.0.eval(scalar))
     }
 }
 
@@ -221,8 +221,8 @@ where
     Input: Copy,
 {
     type Output = (G::Output, H::Output);
-    fn gen(&self, input: Input) -> Self::Output {
-        (self.0.gen(input), self.1.gen(input))
+    fn eval(&self, input: Input) -> Self::Output {
+        (self.0.eval(input), self.1.eval(input))
     }
 }
 
@@ -275,8 +275,8 @@ where
     G: DiscreteGenerator,
 {
     type Output = G::Output;
-    fn gen(&self, input: usize) -> Self::Output {
-        self.0.gen(input % self.0.len())
+    fn eval(&self, input: usize) -> Self::Output {
+        self.0.eval(input % self.0.len())
     }
 }
 
@@ -311,8 +311,8 @@ where
     G: DiscreteGenerator,
 {
     type Output = G::Output;
-    fn gen(&self, input: usize) -> Self::Output {
-        self.inner.gen(input % self.inner.len())
+    fn eval(&self, input: usize) -> Self::Output {
+        self.inner.eval(input % self.inner.len())
     }
 }
 
@@ -334,7 +334,7 @@ mod test {
     fn input_transform() {
         let identity = Identity {};
         let transformed = TransformInput::new(identity, 0.0, 2.0);
-        assert_f64_near!(transformed.gen(1.0), 2.0);
+        assert_f64_near!(transformed.eval(1.0), 2.0);
         let results = [0.0, 1.0, 2.0];
         // try to extract
         let extractor = transformed.extract([0.0, 0.5, 1.0]);
@@ -356,8 +356,8 @@ mod test {
         let identity = Identity {};
         let slice = Slice::new(identity, 10.0..100.0);
         let results = [10.0, 100.0];
-        assert_f64_near!(slice.gen(0.0), 10.0);
-        assert_f64_near!(slice.gen(1.0), 100.0);
+        assert_f64_near!(slice.eval(0.0), 10.0);
+        assert_f64_near!(slice.eval(1.0), 100.0);
         for (val, res) in slice.take(results.len()).zip(results.iter()) {
             assert_f64_near!(val, res);
         }

--- a/src/base/generator.rs
+++ b/src/base/generator.rs
@@ -16,7 +16,7 @@ pub trait Generator<Input> {
     /// The element outputted
     type Output;
     /// Method to generate the element at the given input
-    fn gen(&self, input: Input) -> Self::Output;
+    fn eval(&self, input: Input) -> Self::Output;
     /// Helper function if one wants to extract values from the interpolation.
     ///
     /// It takes an iterator of items which are inputed into the [`gen()`] method
@@ -176,8 +176,8 @@ pub trait Generator<Input> {
 // Make references of generators also generators
 impl<G: Generator<I> + ?Sized, I> Generator<I> for &G {
     type Output = G::Output;
-    fn gen(&self, input: I) -> Self::Output {
-        (**self).gen(input)
+    fn eval(&self, input: I) -> Self::Output {
+        (**self).eval(input)
     }
 }
 
@@ -317,14 +317,14 @@ pub trait DiscreteGenerator: Generator<usize> {
         if self.is_empty() {
             return None;
         }
-        Some(self.gen(0))
+        Some(self.eval(0))
     }
     /// Returns the last element of the generator, or `None` if it is empty.
     fn last(&self) -> Option<Self::Output> {
         if self.is_empty() {
             return None;
         }
-        Some(self.gen(self.len() - 1))
+        Some(self.eval(self.len() - 1))
     }
     /// Returns `true` if the generator does not generate any elements.
     fn is_empty(&self) -> bool {
@@ -374,7 +374,7 @@ pub trait ConstDiscreteGenerator<const N: usize>: DiscreteGenerator {
     {
         let mut arr = [Default::default(); N];
         for (i, val) in arr.iter_mut().enumerate().take(N) {
-            *val = self.gen(i);
+            *val = self.eval(i);
         }
         arr
     }
@@ -412,7 +412,7 @@ where
     type Item = G::Output;
     fn next(&mut self) -> Option<Self::Item> {
         if self.front < self.back {
-            let res = self.gen.gen(self.front);
+            let res = self.gen.eval(self.front);
             self.front += 1;
             return Some(res);
         }
@@ -444,7 +444,7 @@ where
 {
     fn next_back(&mut self) -> Option<Self::Item> {
         if self.front < self.back {
-            let res = self.gen.gen(self.back);
+            let res = self.gen.eval(self.back);
             self.back -= 1;
             return Some(res);
         }
@@ -481,7 +481,7 @@ where
 {
     type Item = G::Output;
     fn next(&mut self) -> Option<Self::Item> {
-        Some(self.generator.gen(self.iterator.next()?))
+        Some(self.generator.eval(self.iterator.next()?))
     }
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.iterator.size_hint()
@@ -490,7 +490,7 @@ where
         self.iterator.count()
     }
     fn nth(&mut self, n: usize) -> Option<Self::Item> {
-        Some(self.generator.gen(self.iterator.nth(n)?))
+        Some(self.generator.eval(self.iterator.nth(n)?))
     }
 }
 
@@ -514,10 +514,10 @@ where
     I: DoubleEndedIterator,
 {
     fn next_back(&mut self) -> Option<Self::Item> {
-        Some(self.generator.gen(self.iterator.next_back()?))
+        Some(self.generator.eval(self.iterator.next_back()?))
     }
     fn nth_back(&mut self, n: usize) -> Option<Self::Item> {
-        Some(self.generator.gen(self.iterator.nth_back(n)?))
+        Some(self.generator.eval(self.iterator.nth_back(n)?))
     }
 }
 

--- a/src/base/list.rs
+++ b/src/base/list.rs
@@ -573,6 +573,12 @@ impl<R, const N: usize> ConstEquidistant<R, N> {
     }
 }
 
+impl<R, const N: usize> Default for ConstEquidistant<R, N> {
+    fn default() -> Self {
+        Self(Default::default())
+    }
+}
+
 impl<R, const N: usize> Signal<usize> for ConstEquidistant<R, N>
 where
     R: Real + FromPrimitive,

--- a/src/base/list.rs
+++ b/src/base/list.rs
@@ -75,7 +75,7 @@ pub trait SortedGenerator: DiscreteGenerator {
         while dist > 0 {
             let step = dist / 2;
             let sample = pointer + step;
-            if element >= self.gen(sample) {
+            if element >= self.eval(sample) {
                 pointer = sample + 1;
                 dist -= step + 1;
             } else {
@@ -218,8 +218,8 @@ pub trait SortedGenerator: DiscreteGenerator {
     where
         Self::Output: Sub<Output = Self::Output> + Div<Output = Self::Output> + Copy,
     {
-        let max = self.gen(max_index);
-        let min = self.gen(min_index);
+        let max = self.eval(max_index);
+        let min = self.eval(min_index);
         (element - min) / (max - min)
     }
 
@@ -238,8 +238,8 @@ pub trait SortedGenerator: DiscreteGenerator {
     where
         Self::Output: Sub<Output = Self::Output> + Div<Output = Self::Output> + Zero + Copy,
     {
-        let max = self.gen(max_index);
-        let min = self.gen(min_index);
+        let max = self.eval(max_index);
+        let min = self.eval(min_index);
         let div = max - min;
         if div.is_zero() {
             return div;
@@ -264,9 +264,9 @@ where
         if col.is_empty() {
             return Ok(Sorted(col));
         }
-        let mut last = col.gen(0);
+        let mut last = col.eval(0);
         for i in 1..col.len() {
-            let current = col.gen(i);
+            let current = col.eval(i);
             match last.partial_cmp(&current) {
                 None | Some(Ordering::Greater) => return Err(NotSorted { index: i }),
                 _ => {
@@ -293,8 +293,8 @@ where
     C: Generator<usize>,
 {
     type Output = C::Output;
-    fn gen(&self, input: usize) -> Self::Output {
-        self.0.gen(input)
+    fn eval(&self, input: usize) -> Self::Output {
+        self.0.eval(input)
     }
 }
 
@@ -413,7 +413,7 @@ where
     R: Real + FromPrimitive,
 {
     type Output = R;
-    fn gen(&self, input: usize) -> R {
+    fn eval(&self, input: usize) -> R {
         self.step * R::from_usize(input).unwrap() + self.offset
     }
 }
@@ -478,7 +478,7 @@ where
         Self::Output: PartialOrd + Copy,
     {
         // extrapolation to the left
-        if element < self.gen(min) {
+        if element < self.eval(min) {
             return min;
         }
         let scaled = (element - self.offset) / self.step;
@@ -578,7 +578,7 @@ where
     R: Real + FromPrimitive,
 {
     type Output = R;
-    fn gen(&self, input: usize) -> R {
+    fn eval(&self, input: usize) -> R {
         R::from_usize(input).unwrap() / R::from_usize(N - 1).unwrap()
     }
 }
@@ -648,7 +648,7 @@ where
         Self::Output: PartialOrd + Copy,
     {
         // extrapolation to the left
-        if element < self.gen(min) {
+        if element < self.eval(min) {
             return min;
         }
         let scaled = element * R::from_usize(N - 1).unwrap();

--- a/src/base/mod.rs
+++ b/src/base/mod.rs
@@ -1,17 +1,15 @@
 mod adaptors;
-mod generator;
 mod list;
+mod signal;
 mod space;
 
 // These get re-exported at the library level.
 #[allow(unreachable_pub)]
 pub use adaptors::{Clamp, Composite, Repeat, Slice, Stack, TransformInput, Wrap};
 #[allow(unreachable_pub)]
-pub use generator::{
-    ConstDiscreteGenerator, Curve, DiscreteGenerator, Extract, Generator, Stepper,
-};
+pub use list::{ConstEquidistant, Equidistant, NotSorted, Sorted, SortedChain};
 #[allow(unreachable_pub)]
-pub use list::{ConstEquidistant, Equidistant, NotSorted, Sorted, SortedGenerator};
+pub use signal::{Chain, ConstChain, Curve, Extract, Signal, Stepper};
 #[allow(unreachable_pub)]
 #[cfg(feature = "std")]
 pub use space::DynSpace;
@@ -19,64 +17,64 @@ pub use space::DynSpace;
 pub use space::{ConstSpace, Space};
 
 #[cfg(feature = "std")]
-impl<T: Copy> Generator<usize> for Vec<T> {
+impl<T: Copy> Signal<usize> for Vec<T> {
     type Output = T;
     fn eval(&self, input: usize) -> Self::Output {
         self[input]
     }
 }
 #[cfg(feature = "std")]
-impl<T: Copy> DiscreteGenerator for Vec<T> {
+impl<T: Copy> Chain for Vec<T> {
     fn len(&self) -> usize {
         self.len()
     }
 }
 
-// /// A stack of values or generators
+// /// A stack of values or signals
 // #[cfg(feature = "std")]
-// impl<G,I> Generator<(usize, I)> for Vec<G>
-// where G: Generator<I>
+// impl<G,I> Signal<(usize, I)> for Vec<G>
+// where G: Signal<I>
 // {
 //     type Output = G::Output;
-//     fn gen(&self, input: (usize, I)) -> Self::Output {
-//         self[input.0].gen(input.1)
+//     fn eval(&self, input: (usize, I)) -> Self::Output {
+//         self[input.0].eval(input.1)
 //     }
 // }
 
-impl<T: Copy> Generator<usize> for &[T] {
+impl<T: Copy> Signal<usize> for &[T] {
     type Output = T;
     fn eval(&self, input: usize) -> Self::Output {
         self[input]
     }
 }
 
-impl<T: Copy> DiscreteGenerator for &[T] {
+impl<T: Copy> Chain for &[T] {
     fn len(&self) -> usize {
         <[T]>::len(self)
     }
 }
 
-impl<T: Copy, const N: usize> Generator<usize> for [T; N] {
+impl<T: Copy, const N: usize> Signal<usize> for [T; N] {
     type Output = T;
     fn eval(&self, input: usize) -> Self::Output {
         self[input]
     }
 }
 
-impl<T: Copy, const N: usize> DiscreteGenerator for [T; N] {
+impl<T: Copy, const N: usize> Chain for [T; N] {
     fn len(&self) -> usize {
         N
     }
 }
 
-impl<T: Copy, const N: usize> ConstDiscreteGenerator<N> for [T; N] {}
+impl<T: Copy, const N: usize> ConstChain<N> for [T; N] {}
 
-// /// A stack of values or generators
-// impl<G,I, const N: usize> Generator<(usize, I)> for [G;N]
-// where G: Generator<I>
+// /// A stack of values or signals
+// impl<G,I, const N: usize> Signal<(usize, I)> for [G;N]
+// where G: Signal<I>
 // {
 //     type Output = G::Output;
-//     fn gen(&self, input: (usize, I)) -> Self::Output {
-//         self[input.0].gen(input.1)
+//     fn eval(&self, input: (usize, I)) -> Self::Output {
+//         self[input.0].eval(input.1)
 //     }
 // }

--- a/src/base/mod.rs
+++ b/src/base/mod.rs
@@ -8,7 +8,7 @@ mod space;
 pub use adaptors::{Clamp, Composite, Repeat, Slice, Stack, TransformInput, Wrap};
 #[allow(unreachable_pub)]
 pub use generator::{
-    ConstDiscreteGenerator, Curve, DiscreteGenerator, Extract, Generator, Stepper, Take,
+    ConstDiscreteGenerator, Curve, DiscreteGenerator, Extract, Generator, Stepper,
 };
 #[allow(unreachable_pub)]
 pub use list::{ConstEquidistant, Equidistant, NotSorted, Sorted, SortedGenerator};

--- a/src/base/mod.rs
+++ b/src/base/mod.rs
@@ -21,7 +21,7 @@ pub use space::{ConstSpace, Space};
 #[cfg(feature = "std")]
 impl<T: Copy> Generator<usize> for Vec<T> {
     type Output = T;
-    fn gen(&self, input: usize) -> Self::Output {
+    fn eval(&self, input: usize) -> Self::Output {
         self[input]
     }
 }
@@ -45,7 +45,7 @@ impl<T: Copy> DiscreteGenerator for Vec<T> {
 
 impl<T: Copy> Generator<usize> for &[T] {
     type Output = T;
-    fn gen(&self, input: usize) -> Self::Output {
+    fn eval(&self, input: usize) -> Self::Output {
         self[input]
     }
 }
@@ -58,7 +58,7 @@ impl<T: Copy> DiscreteGenerator for &[T] {
 
 impl<T: Copy, const N: usize> Generator<usize> for [T; N] {
     type Output = T;
-    fn gen(&self, input: usize) -> Self::Output {
+    fn eval(&self, input: usize) -> Self::Output {
         self[input]
     }
 }

--- a/src/base/signal.rs
+++ b/src/base/signal.rs
@@ -650,18 +650,16 @@ mod test {
 
     #[test]
     fn stepper() {
-        let mut stepper = Stepper::normalized(11);
+        let mut stepper = Stepper::<f64>::normalized(11);
         let res = [0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0];
-        for i in 0..=10 {
-            let val = stepper.next().unwrap();
-            assert_f64_near!(val, res[i]);
+        for val in res {
+            assert_f64_near!(val, stepper.next().unwrap());
         }
 
         let mut stepper = Stepper::new(5, 3.0, 5.0);
         let res = [3.0, 3.5, 4.0, 4.5, 5.0];
-        for i in 0..5 {
-            let val = stepper.next().unwrap();
-            assert_f64_near!(val, res[i]);
+        for val in res {
+            assert_f64_near!(val, stepper.next().unwrap());
         }
     }
 }

--- a/src/base/signal.rs
+++ b/src/base/signal.rs
@@ -19,7 +19,7 @@ pub trait Signal<Input> {
     fn eval(&self, input: Input) -> Self::Output;
     /// Helper function if one wants to extract values from the interpolation.
     ///
-    /// It takes an iterator of items which are inputed into the [`gen()`] method
+    /// It takes an iterator of items which are inputed into the [`eval()`] method
     /// and returns an iterator of the corresponding outputs.
     ///
     /// # Examples
@@ -44,7 +44,7 @@ pub trait Signal<Input> {
     /// # }
     /// ```
     ///
-    /// [`gen()`]: Self::gen()
+    /// [`eval()`]: Self::eval()
     fn extract<I, J>(self, iterator: I) -> Extract<Self, J>
     where
         Self: Sized,
@@ -134,7 +134,7 @@ pub trait Signal<Input> {
     }
     /// Helper function if one wants to sample values from the interpolation.
     ///
-    /// It takes an iterator of items which are inputed into the [`gen()`] method
+    /// It takes an iterator of items which are inputed into the [`eval()`] method
     /// and returns an iterator of the corresponding outputs.
     ///
     /// This acts the same as `signal.by_ref().extract()`.
@@ -162,7 +162,7 @@ pub trait Signal<Input> {
     /// # }
     /// ```
     ///
-    /// [`gen()`]: Self::gen()
+    /// [`eval()`]: Self::eval()
     fn sample<I, J>(&self, iterator: I) -> Extract<&Self, J>
     where
         Self: Sized,

--- a/src/bezier/error.rs
+++ b/src/bezier/error.rs
@@ -10,7 +10,7 @@ use std::error::Error;
 #[derive(Debug, Copy, Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub enum BezierError {
-    /// Error returned if the generator does not contain any elements.
+    /// Error returned if the signal does not contain any elements.
     Empty(Empty),
     /// Error returned if the given workspace is too small for the interpolation to use.
     TooSmallWorkspace(TooSmallWorkspace),

--- a/src/bezier/mod.rs
+++ b/src/bezier/mod.rs
@@ -4,7 +4,7 @@
 //!
 //! ```rust
 //! # use std::error::Error;
-//! # use enterpolation::{bezier::{Bezier, BezierError}, Generator, Curve};
+//! # use enterpolation::{bezier::{Bezier, BezierError}, Signal, Curve};
 //! # use assert_float_eq::{afe_is_f64_near, afe_near_error_msg, assert_f64_near};
 //! #
 //! # fn main() -> Result<(), BezierError> {
@@ -26,7 +26,7 @@
 //!
 //! [`BezierBuilder`]: BezierBuilder
 use crate::builder::Unknown;
-use crate::{Curve, DiscreteGenerator, Generator, Space};
+use crate::{Chain, Curve, Signal, Space};
 use core::marker::PhantomData;
 use core::ops::{Mul, Sub};
 use num_traits::cast::FromPrimitive;
@@ -177,7 +177,7 @@ impl Bezier<Unknown, Unknown, Unknown> {
     ///
     /// ```rust
     /// # use std::error::Error;
-    /// # use enterpolation::{bezier::{Bezier, BezierError}, Generator, Curve};
+    /// # use enterpolation::{bezier::{Bezier, BezierError}, Signal, Curve};
     /// # use assert_float_eq::{afe_is_f64_near, afe_near_error_msg, assert_f64_near};
     /// #
     /// # fn main() -> Result<(), BezierError> {
@@ -211,7 +211,7 @@ impl Bezier<Unknown, Unknown, Unknown> {
 
 impl<R, E, S> Bezier<R, E, S>
 where
-    E: DiscreteGenerator,
+    E: Chain,
     S: Space<E::Output>,
 {
     /// Creates a workspace and copies all elements into it.
@@ -229,9 +229,9 @@ where
     }
 }
 
-impl<R, E, S> Generator<R> for Bezier<R, E, S>
+impl<R, E, S> Signal<R> for Bezier<R, E, S>
 where
-    E: DiscreteGenerator,
+    E: Chain,
     E::Output: Merge<R> + Copy,
     S: Space<E::Output>,
     R: Real,
@@ -248,7 +248,7 @@ where
 
 impl<R, E, S> Curve<R> for Bezier<R, E, S>
 where
-    E: DiscreteGenerator,
+    E: Chain,
     E::Output: Merge<R> + Copy,
     S: Space<E::Output>,
     R: Real,
@@ -261,7 +261,7 @@ where
 
 impl<R, E, S> Bezier<R, E, S>
 where
-    E: DiscreteGenerator,
+    E: Chain,
     E::Output: Merge<R> + Mul<R, Output = E::Output> + Sub<Output = E::Output> + Copy,
     S: Space<E::Output>,
     R: Real + FromPrimitive,
@@ -287,7 +287,7 @@ where
 
 impl<R, E, S> Bezier<R, E, S>
 where
-    E: DiscreteGenerator,
+    E: Chain,
     S: Space<E::Output>,
 {
     /// Create generic bezier curve.
@@ -314,7 +314,7 @@ where
     /// # Panics
     ///
     /// May panic or return non-expected values if the space given is less than the number of elements.
-    /// Will panic if the given generator does not generate any element.
+    /// Will panic if the given signal does not generate any element.
     pub fn new_unchecked(elements: E, space: S) -> Self {
         Bezier {
             space,

--- a/src/bezier/mod.rs
+++ b/src/bezier/mod.rs
@@ -223,7 +223,7 @@ where
             .enumerate()
             .take(self.elements.len())
         {
-            *val = self.elements.gen(i);
+            *val = self.elements.eval(i);
         }
         workspace
     }
@@ -237,7 +237,7 @@ where
     R: Real,
 {
     type Output = E::Output;
-    fn gen(&self, scalar: R) -> E::Output {
+    fn eval(&self, scalar: R) -> E::Output {
         // we pass only slices to guarantee the size of workspace to match the number of elements
         bezier(
             &mut self.workspace().as_mut()[..self.elements.len()],
@@ -337,8 +337,8 @@ mod test {
             .constant()
             .build()
             .unwrap();
-        assert_f64_near!(bez.gen(2.0), 820.0);
-        assert_f64_near!(bez.gen(-1.0), 280.0);
+        assert_f64_near!(bez.eval(2.0), 820.0);
+        assert_f64_near!(bez.eval(-1.0), 280.0);
     }
 
     #[test]

--- a/src/bspline/adaptors.rs
+++ b/src/bspline/adaptors.rs
@@ -1,7 +1,7 @@
 use crate::builder::TooFewElements;
-use crate::{DiscreteGenerator, Generator, SortedGenerator};
+use crate::{Chain, Signal, SortedChain};
 
-/// DiscreteGenerator Adaptor which repeats its first and last element `n` more times.
+/// Chain Adaptor which repeats its first and last element `n` more times.
 #[derive(Debug, Copy, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct BorderBuffer<G> {
@@ -11,9 +11,9 @@ pub struct BorderBuffer<G> {
 
 impl<G> BorderBuffer<G>
 where
-    G: DiscreteGenerator,
+    G: Chain,
 {
-    /// Creates a generator which repeats the first and last element of the given generator `n` more times.
+    /// Creates a chain which repeats the first and last element of the given chain `n` more times.
     pub fn new(inner: G, n: usize) -> Self {
         BorderBuffer { inner, n }
     }
@@ -39,9 +39,9 @@ where
     }
 }
 
-impl<G> Generator<usize> for BorderBuffer<G>
+impl<G> Signal<usize> for BorderBuffer<G>
 where
-    G: DiscreteGenerator,
+    G: Chain,
 {
     type Output = G::Output;
     fn eval(&self, input: usize) -> Self::Output {
@@ -50,18 +50,18 @@ where
     }
 }
 
-impl<G> DiscreteGenerator for BorderBuffer<G>
+impl<G> Chain for BorderBuffer<G>
 where
-    G: DiscreteGenerator,
+    G: Chain,
 {
     fn len(&self) -> usize {
         self.inner.len() + 2 * self.n
     }
 }
 
-impl<G> SortedGenerator for BorderBuffer<G>
+impl<G> SortedChain for BorderBuffer<G>
 where
-    G: SortedGenerator,
+    G: SortedChain,
 {
     fn strict_upper_bound_clamped(&self, element: Self::Output, min: usize, max: usize) -> usize
     where
@@ -84,11 +84,11 @@ where
     }
 }
 
-/// DiscreteGenerator Adaptor which deletes the first and last element.
+/// Chain Adaptor which deletes the first and last element.
 ///
 /// # Panics
 ///
-/// Using this Generator may cause a panic if the underlying generator has less than two elements.
+/// Using this chain may cause a panic if the underlying chain has less than two elements.
 #[derive(Debug, Copy, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct BorderDeletion<G> {
@@ -97,9 +97,9 @@ pub struct BorderDeletion<G> {
 
 impl<G> BorderDeletion<G>
 where
-    G: DiscreteGenerator,
+    G: Chain,
 {
-    /// Creates a generator ignores the first and last element.
+    /// Creates a chain, ignores the first and last element.
     pub fn new(inner: G) -> Result<Self, TooFewElements> {
         if inner.len() < 2 {
             return Err(TooFewElements::new(inner.len()));
@@ -108,9 +108,9 @@ where
     }
 }
 
-impl<G> Generator<usize> for BorderDeletion<G>
+impl<G> Signal<usize> for BorderDeletion<G>
 where
-    G: DiscreteGenerator,
+    G: Chain,
 {
     type Output = G::Output;
     fn eval(&self, input: usize) -> Self::Output {
@@ -118,21 +118,21 @@ where
     }
 }
 
-impl<G> DiscreteGenerator for BorderDeletion<G>
+impl<G> Chain for BorderDeletion<G>
 where
-    G: DiscreteGenerator,
+    G: Chain,
 {
     /// # Panics
     ///
-    /// May Panic if the underlying generator has less than two elements.
+    /// May Panic if the underlying chain has less than two elements.
     fn len(&self) -> usize {
         self.inner.len() - 2
     }
 }
 
-impl<G> SortedGenerator for BorderDeletion<G>
+impl<G> SortedChain for BorderDeletion<G>
 where
-    G: SortedGenerator,
+    G: SortedChain,
 {
     fn strict_upper_bound_clamped(&self, element: Self::Output, min: usize, max: usize) -> usize
     where
@@ -148,7 +148,7 @@ where
 #[cfg(test)]
 mod test {
     use super::{BorderBuffer, BorderDeletion};
-    use crate::{DiscreteGenerator, Equidistant, SortedGenerator};
+    use crate::{Chain, Equidistant, SortedChain};
 
     #[test]
     fn borderdeletion() {

--- a/src/bspline/adaptors.rs
+++ b/src/bspline/adaptors.rs
@@ -44,9 +44,9 @@ where
     G: DiscreteGenerator,
 {
     type Output = G::Output;
-    fn gen(&self, input: usize) -> Self::Output {
+    fn eval(&self, input: usize) -> Self::Output {
         let clamped = input.max(self.n).min(self.inner.len() + self.n - 1);
-        self.inner.gen(clamped - self.n)
+        self.inner.eval(clamped - self.n)
     }
 }
 
@@ -113,8 +113,8 @@ where
     G: DiscreteGenerator,
 {
     type Output = G::Output;
-    fn gen(&self, input: usize) -> Self::Output {
-        self.inner.gen(input + 1)
+    fn eval(&self, input: usize) -> Self::Output {
+        self.inner.eval(input + 1)
     }
 }
 

--- a/src/bspline/builder.rs
+++ b/src/bspline/builder.rs
@@ -72,12 +72,12 @@ impl<R> UnknownDomain<R> {
 ///
 /// Before building, one has to give information for:
 /// - The elements the interpolation should use. Methods like [`elements()`] and [`elements_with_weights`()]
-///     exist for that cause.
+///   exist for that cause.
 /// - The knots the interpolation uses. Either by giving them directly with [`knots()`] or by using
-///     equidistant knots with [`equidistant()`].
+///   equidistant knots with [`equidistant()`].
 /// - A workspace to use, that is, a mutable slice-like object to do operations on.
-///     Usually this is done by calling [`constant()`] or [`dynamic()`].
-///     [`workspace()`] is also posbbile for a custom workspace.
+///   Usually this is done by calling [`constant()`] or [`dynamic()`].
+///   [`workspace()`] is also posbbile for a custom workspace.
 ///
 /// Furthermore one may want to use different modes, toggled by the methods [`open()`],[`clamped()`]
 /// and [`legacy()`], where [`open()`] is the default one.
@@ -111,12 +111,12 @@ pub struct BSplineDirector<K, E, S, W, M> {
 ///
 /// Before building, one has to give information for:
 /// - The elements the interpolation should use. Methods like [`elements()`] and [`elements_with_weights`()]
-///     exist for that cause.
+///   exist for that cause.
 /// - The knots the interpolation uses. Either by giving them directly with [`knots()`] or by using
-///     equidistant knots with [`equidistant()`].
+///   equidistant knots with [`equidistant()`].
 /// - A workspace to use, that is, a mutable slice-like object to do operations on.
-///     Usually this is done by calling [`constant()`] or [`dynamic()`].
-///     [`workspace()`] is also posbbile for a custom workspace.
+///   Usually this is done by calling [`constant()`] or [`dynamic()`].
+///   [`workspace()`] is also posbbile for a custom workspace.
 ///
 /// Furthermore one may want to use different modes, toggled by the methods [`open()`],[`clamped()`]
 /// and [`legacy()`], where [`open()`] is the default one.

--- a/src/bspline/error.rs
+++ b/src/bspline/error.rs
@@ -1,8 +1,8 @@
 //! All error types for bspline interpolation.
 #[allow(unreachable_pub)]
-pub use crate::builder::{TooFewElements, TooFewKnots, TooSmallWorkspace};
-#[allow(unreachable_pub)]
 pub use crate::NotSorted;
+#[allow(unreachable_pub)]
+pub use crate::builder::{TooFewElements, TooFewKnots, TooSmallWorkspace};
 
 use core::{convert::From, fmt};
 #[cfg(feature = "std")]

--- a/src/bspline/mod.rs
+++ b/src/bspline/mod.rs
@@ -6,7 +6,7 @@
 //!
 //! ```rust
 //! # use std::error::Error;
-//! # use enterpolation::{bspline::{BSpline, BSplineError}, Generator, Curve};
+//! # use enterpolation::{bspline::{BSpline, BSplineError}, Signal, Curve};
 //! # use assert_float_eq::{afe_is_f64_near, afe_near_error_msg, assert_f64_near};
 //! #
 //! # fn main() -> Result<(), BSplineError> {
@@ -45,7 +45,7 @@ pub use error::{
 };
 
 use crate::builder::Unknown;
-use crate::{Curve, DiscreteGenerator, Generator, SortedGenerator, Space};
+use crate::{Chain, Curve, Signal, SortedChain, Space};
 use builder::Open;
 use num_traits::real::Real;
 use topology_traits::Merge;
@@ -79,7 +79,7 @@ impl BSpline<Unknown, Unknown, Unknown> {
     ///
     /// ```rust
     /// # use std::error::Error;
-    /// # use enterpolation::{bspline::{BSpline, BSplineError}, Generator, Curve};
+    /// # use enterpolation::{bspline::{BSpline, BSplineError}, Signal, Curve};
     /// # use assert_float_eq::{afe_is_f64_near, afe_near_error_msg, assert_f64_near};
     /// #
     /// # fn main() -> Result<(), BSplineError> {
@@ -119,7 +119,7 @@ impl BSpline<Unknown, Unknown, Unknown> {
 
 impl<K, E, S> BSpline<K, E, S>
 where
-    E: DiscreteGenerator,
+    E: Chain,
     S: Space<E::Output>,
 {
     /// Creates a workspace and copies degree+1 elements into it, starting from given index.
@@ -133,13 +133,13 @@ where
     }
 }
 
-impl<K, E, S, R> Generator<R> for BSpline<K, E, S>
+impl<K, E, S, R> Signal<R> for BSpline<K, E, S>
 where
-    E: DiscreteGenerator,
+    E: Chain,
     S: Space<E::Output>,
     E::Output: Merge<R> + Copy,
     R: Real + Debug,
-    K: SortedGenerator<Output = R>,
+    K: SortedChain<Output = R>,
 {
     type Output = E::Output;
     fn eval(&self, scalar: R) -> E::Output {
@@ -171,11 +171,11 @@ where
 
 impl<K, E, S, R> Curve<R> for BSpline<K, E, S>
 where
-    E: DiscreteGenerator,
+    E: Chain,
     S: Space<E::Output>,
     E::Output: Merge<R> + Copy,
     R: Real + Debug,
-    K: SortedGenerator<Output = R>,
+    K: SortedChain<Output = R>,
 {
     fn domain(&self) -> [R; 2] {
         [
@@ -187,8 +187,8 @@ where
 
 impl<K, E, S> BSpline<K, E, S>
 where
-    E: DiscreteGenerator,
-    K: SortedGenerator,
+    E: Chain,
+    K: SortedChain,
     S: Space<E::Output>,
 {
     /// Creates a bspline curve of elements and knots given.
@@ -237,8 +237,8 @@ where
 
 impl<K, E, S> BSpline<K, E, S>
 where
-    E: DiscreteGenerator,
-    K: SortedGenerator,
+    E: Chain,
+    K: SortedChain,
     S: Space<E::Output>,
 {
     /// Creates a bspline curve of elements and knots given.

--- a/src/bspline/mod.rs
+++ b/src/bspline/mod.rs
@@ -127,7 +127,7 @@ where
         let mut workspace = self.space.workspace();
         let mut_workspace = workspace.as_mut();
         for (i, val) in mut_workspace.iter_mut().enumerate().take(self.degree + 1) {
-            *val = self.elements.gen(index - self.degree + i);
+            *val = self.elements.eval(index - self.degree + i);
         }
         workspace
     }
@@ -142,7 +142,7 @@ where
     K: SortedGenerator<Output = R>,
 {
     type Output = E::Output;
-    fn gen(&self, scalar: R) -> E::Output {
+    fn eval(&self, scalar: R) -> E::Output {
         // we do NOT calculaute a possible multiplicity of the scalar, as we assume
         // the chance of hitting a knot is almost zero.
         let lower_cut = self.degree;
@@ -160,8 +160,8 @@ where
         for r in 1..=self.degree {
             for j in 0..=(self.degree - r) {
                 let i = j + r + index - self.degree;
-                let factor = (scalar - self.knots.gen(i - 1))
-                    / (self.knots.gen(i + self.degree - r) - self.knots.gen(i - 1));
+                let factor = (scalar - self.knots.eval(i - 1))
+                    / (self.knots.eval(i + self.degree - r) - self.knots.eval(i - 1));
                 elements[j] = elements[j].merge(elements[j + 1], factor);
             }
         }
@@ -179,8 +179,8 @@ where
 {
     fn domain(&self) -> [R; 2] {
         [
-            self.knots.gen(self.degree - 1),
-            self.knots.gen(self.knots.len() - self.degree),
+            self.knots.eval(self.degree - 1),
+            self.knots.eval(self.knots.len() - self.degree),
         ]
     }
 }
@@ -286,7 +286,7 @@ mod test {
             .build()
             .unwrap();
         for i in 0..expect.len() {
-            assert_f32_near!(spline.gen(expect[i].0), expect[i].1);
+            assert_f32_near!(spline.eval(expect[i].0), expect[i].1);
         }
     }
 
@@ -312,7 +312,7 @@ mod test {
             .build()
             .unwrap();
         for i in 0..expect.len() {
-            assert_f32_near!(spline.gen(expect[i].0), expect[i].1);
+            assert_f32_near!(spline.eval(expect[i].0), expect[i].1);
         }
     }
 
@@ -337,7 +337,7 @@ mod test {
             .build()
             .unwrap();
         for i in 0..expect.len() {
-            assert_f32_near!(spline.gen(expect[i].0), expect[i].1);
+            assert_f32_near!(spline.eval(expect[i].0), expect[i].1);
         }
     }
 
@@ -365,7 +365,7 @@ mod test {
             .build()
             .unwrap();
         for i in 0..expect.len() {
-            assert_f32_near!(spline.gen(expect[i].0), expect[i].1);
+            assert_f32_near!(spline.eval(expect[i].0), expect[i].1);
         }
     }
 
@@ -393,7 +393,7 @@ mod test {
             .build()
             .unwrap();
         for i in 0..expect.len() {
-            assert_f64_near!(spline.gen(expect[i].0), expect[i].1);
+            assert_f64_near!(spline.eval(expect[i].0), expect[i].1);
         }
     }
 

--- a/src/bspline/mod.rs
+++ b/src/bspline/mod.rs
@@ -285,8 +285,8 @@ mod test {
             .constant::<2>()
             .build()
             .unwrap();
-        for i in 0..expect.len() {
-            assert_f32_near!(spline.eval(expect[i].0), expect[i].1);
+        for (input, output) in expect {
+            assert_f32_near!(spline.eval(input), output);
         }
     }
 
@@ -311,8 +311,8 @@ mod test {
             .constant::<3>()
             .build()
             .unwrap();
-        for i in 0..expect.len() {
-            assert_f32_near!(spline.eval(expect[i].0), expect[i].1);
+        for (input, output) in expect {
+            assert_f32_near!(spline.eval(input), output);
         }
     }
 
@@ -336,8 +336,8 @@ mod test {
             .constant::<4>()
             .build()
             .unwrap();
-        for i in 0..expect.len() {
-            assert_f32_near!(spline.eval(expect[i].0), expect[i].1);
+        for (input, output) in expect {
+            assert_f32_near!(spline.eval(input), output);
         }
     }
 
@@ -364,8 +364,8 @@ mod test {
             .constant::<5>()
             .build()
             .unwrap();
-        for i in 0..expect.len() {
-            assert_f32_near!(spline.eval(expect[i].0), expect[i].1);
+        for (input, output) in expect {
+            assert_f32_near!(spline.eval(input), output);
         }
     }
 
@@ -392,8 +392,8 @@ mod test {
             .constant::<5>()
             .build()
             .unwrap();
-        for i in 0..expect.len() {
-            assert_f64_near!(spline.eval(expect[i].0), expect[i].1);
+        for (input, output) in expect {
+            assert_f64_near!(spline.eval(input), output);
         }
     }
 

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -42,6 +42,12 @@ impl<R> NormalizedInput<R> {
     }
 }
 
+impl<R> Default for NormalizedInput<R> {
+    fn default() -> Self {
+        Self(Default::default())
+    }
+}
+
 /// Struct to indicate which input domain to use
 #[cfg(feature = "bezier")]
 #[derive(Debug, Copy, Clone)]
@@ -71,9 +77,15 @@ impl<R> Type<R> {
     }
 }
 
+impl<R> Default for Type<R> {
+    fn default() -> Self {
+        Self(Default::default())
+    }
+}
+
 /// Error returned if if there are no elements.
 #[cfg(feature = "bezier")]
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Default, Copy, Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct Empty {}
 

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -88,7 +88,7 @@ impl Empty {
 #[cfg(feature = "bezier")]
 impl fmt::Display for Empty {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "No elements given, an empty generator is not allowed.")
+        write!(f, "No elements given, an empty signal is not allowed.")
     }
 }
 
@@ -107,7 +107,11 @@ pub struct TooFewElements {
 #[cfg(any(feature = "linear", feature = "bspline"))]
 impl fmt::Display for TooFewElements {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "To few elements given for the interpolation. {} elements were given, but at least 2 are necessary.", self.found)
+        write!(
+            f,
+            "To few elements given for the interpolation. {} elements were given, but at least 2 are necessary.",
+            self.found
+        )
     }
 }
 
@@ -134,7 +138,11 @@ pub struct TooFewKnots {
 #[cfg(feature = "bspline")]
 impl fmt::Display for TooFewKnots {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "To few knots given for the interpolation. {} knots were given, but at least 2 are necessary.", self.found)
+        write!(
+            f,
+            "To few knots given for the interpolation. {} knots were given, but at least 2 are necessary.",
+            self.found
+        )
     }
 }
 

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -42,6 +42,7 @@ impl<R> NormalizedInput<R> {
     }
 }
 
+#[cfg(feature = "bezier")]
 impl<R> Default for NormalizedInput<R> {
     fn default() -> Self {
         Self(Default::default())
@@ -77,6 +78,7 @@ impl<R> Type<R> {
     }
 }
 
+#[cfg(any(feature = "linear", feature = "bspline"))]
 impl<R> Default for Type<R> {
     fn default() -> Self {
         Self(Default::default())

--- a/src/easing/mod.rs
+++ b/src/easing/mod.rs
@@ -31,7 +31,7 @@ where
     F: Fn(R) -> R,
 {
     type Output = R;
-    fn gen(&self, input: R) -> R {
+    fn eval(&self, input: R) -> R {
         (self.func)(input)
     }
 }
@@ -66,7 +66,7 @@ impl Default for Identity {
 
 impl<R> Generator<R> for Identity {
     type Output = R;
-    fn gen(&self, input: R) -> R {
+    fn eval(&self, input: R) -> R {
         input
     }
 }

--- a/src/easing/mod.rs
+++ b/src/easing/mod.rs
@@ -3,7 +3,7 @@
 //! Easing function, in the context of this crate, are function which take as only input
 //! a real number in [0.0,1.0] and return a real number in [0.0,1.0].
 
-use crate::{Curve, Generator};
+use crate::{Curve, Signal};
 use num_traits::real::Real;
 use num_traits::FromPrimitive;
 
@@ -26,7 +26,7 @@ impl<F> FuncEase<F> {
     }
 }
 
-impl<F, R> Generator<R> for FuncEase<F>
+impl<F, R> Signal<R> for FuncEase<F>
 where
     F: Fn(R) -> R,
 {
@@ -64,7 +64,7 @@ impl Default for Identity {
     }
 }
 
-impl<R> Generator<R> for Identity {
+impl<R> Signal<R> for Identity {
     type Output = R;
     fn eval(&self, input: R) -> R {
         input

--- a/src/easing/mod.rs
+++ b/src/easing/mod.rs
@@ -4,8 +4,8 @@
 //! a real number in [0.0,1.0] and return a real number in [0.0,1.0].
 
 use crate::{Curve, Signal};
-use num_traits::real::Real;
 use num_traits::FromPrimitive;
+use num_traits::real::Real;
 
 mod plateau;
 pub use plateau::Plateau;

--- a/src/easing/plateau.rs
+++ b/src/easing/plateau.rs
@@ -1,7 +1,7 @@
 use crate::easing::smoothstep;
 use crate::{Curve, Signal};
-use num_traits::real::Real;
 use num_traits::FromPrimitive;
+use num_traits::real::Real;
 
 /// Plateau is an easing curve which - therefore the name - create constant plateaus if given to
 /// an interpolation which works with factors for which an easing function gets applied.

--- a/src/easing/plateau.rs
+++ b/src/easing/plateau.rs
@@ -1,5 +1,5 @@
 use crate::easing::smoothstep;
-use crate::{Curve, Generator};
+use crate::{Curve, Signal};
 use num_traits::real::Real;
 use num_traits::FromPrimitive;
 
@@ -47,7 +47,7 @@ where
     }
 }
 
-impl<R> Generator<R> for Plateau<R>
+impl<R> Signal<R> for Plateau<R>
 where
     R: Real + FromPrimitive,
 {

--- a/src/easing/plateau.rs
+++ b/src/easing/plateau.rs
@@ -52,7 +52,7 @@ where
     R: Real + FromPrimitive,
 {
     type Output = R;
-    fn gen(&self, input: R) -> R {
+    fn eval(&self, input: R) -> R {
         smoothstep(over_clamp(input, self.min, self.max))
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@
     variant_size_differences
 )]
 
+#[cfg(test)]
 #[macro_use]
 extern crate assert_float_eq;
 
@@ -43,8 +44,8 @@ pub use topology_traits::Merge;
 pub use base::DynSpace;
 pub use base::{
     Chain, Clamp, Composite, ConstChain, ConstEquidistant, ConstSpace, Curve, Equidistant, Extract,
-    NotSorted, Repeat, Signal, Slice, Sorted, SortedChain, Space, Stack, Stepper,
-    TransformInput, Wrap,
+    NotSorted, Repeat, Signal, Slice, Sorted, SortedChain, Space, Stack, Stepper, TransformInput,
+    Wrap,
 };
 pub use easing::Identity;
 // pub use weights::{Homogeneous, Weighted, Weights, IntoWeight};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,9 +42,9 @@ pub use topology_traits::Merge;
 #[cfg(feature = "std")]
 pub use base::DynSpace;
 pub use base::{
-    Clamp, Composite, ConstDiscreteGenerator, ConstEquidistant, ConstSpace, Curve,
-    DiscreteGenerator, Equidistant, Extract, Generator, NotSorted, Repeat, Slice, Sorted,
-    SortedGenerator, Space, Stack, Stepper, TransformInput, Wrap,
+    Chain, Clamp, Composite, ConstChain, ConstEquidistant, ConstSpace, Curve, Equidistant, Extract,
+    NotSorted, Repeat, Signal, Slice, Sorted, SortedChain, Space, Stack, Stepper,
+    TransformInput, Wrap,
 };
 pub use easing::Identity;
 // pub use weights::{Homogeneous, Weighted, Weights, IntoWeight};

--- a/src/linear/error.rs
+++ b/src/linear/error.rs
@@ -1,7 +1,7 @@
 //! All error types for linear interpolation.
 
-pub use crate::builder::TooFewElements;
 pub use crate::NotSorted;
+pub use crate::builder::TooFewElements;
 use core::{convert::From, fmt};
 
 #[cfg(feature = "std")]

--- a/src/linear/mod.rs
+++ b/src/linear/mod.rs
@@ -119,12 +119,12 @@ where
     /// # Panics
     ///
     /// Panics if `scalar` is NaN or similar.
-    fn gen(&self, scalar: K::Output) -> Self::Output {
+    fn eval(&self, scalar: K::Output) -> Self::Output {
         //we use upper_border_with_factor as this allows us a performance improvement for equidistant knots
         let (min_index, max_index, factor) = self.knots.upper_border(scalar);
-        let min_point = self.elements.gen(min_index);
-        let max_point = self.elements.gen(max_index);
-        min_point.merge(max_point, self.easing.gen(factor))
+        let min_point = self.elements.eval(min_index);
+        let max_point = self.elements.eval(max_index);
+        min_point.merge(max_point, self.easing.eval(factor))
     }
 }
 
@@ -261,10 +261,10 @@ mod test {
             .knots([1.0, 2.0, 3.0, 4.0])
             .build()
             .unwrap();
-        assert_f64_near!(lin.gen(1.5), 60.0);
-        assert_f64_near!(lin.gen(2.5), 50.0);
-        assert_f64_near!(lin.gen(-1.0), -140.0);
-        assert_f64_near!(lin.gen(5.0), 400.0);
+        assert_f64_near!(lin.eval(1.5), 60.0);
+        assert_f64_near!(lin.eval(2.5), 50.0);
+        assert_f64_near!(lin.eval(-1.0), -140.0);
+        assert_f64_near!(lin.eval(5.0), 400.0);
     }
 
     #[test]
@@ -275,7 +275,7 @@ mod test {
             .normalized()
             .build()
             .unwrap();
-        assert_f64_near!(lin.gen(0.5), 0.1);
+        assert_f64_near!(lin.eval(0.5), 0.1);
         // const LIN : Linear<f64,f64,ConstEquidistant<f64>,CollectionWrapper<[f64;4],f64>> = Linear::new_equidistant_unchecked([20.0,100.0,0.0,200.0]);
     }
 

--- a/src/linear/mod.rs
+++ b/src/linear/mod.rs
@@ -211,7 +211,7 @@ impl<R, T, const N: usize> Linear<ConstEquidistant<R, N>, [T; N], Identity> {
 ///
 /// This alias is used for convenience to help create constant curves.
 ///
-/// **Because this is an alias, not all its methods are listed here. See the [`Linear`](crate::linear::Linear) type too.**
+/// **Because this is an alias, not all its methods are listed here. See the [`Linear`] type too.**
 pub type ConstEquidistantLinear<R, T, const N: usize> =
     Linear<ConstEquidistant<R, N>, [T; N], Identity>;
 

--- a/src/linear/mod.rs
+++ b/src/linear/mod.rs
@@ -232,9 +232,8 @@ mod test {
             .unwrap();
         let expected = [20.0, 60.0, 100.0, 50.0, 0.0, 100.0, 200.0];
         let mut iter = lin.take(expected.len());
-        for i in 0..expected.len() {
-            let val = iter.next().unwrap();
-            assert_f64_near!(val, expected[i]);
+        for val in expected {
+            assert_f64_near!(val, iter.next().unwrap());
         }
     }
 
@@ -248,9 +247,8 @@ mod test {
             .unwrap();
         let expected = [20.0, 60.0, 100.0, 50.0, 0.0, 100.0, 200.0];
         let mut iter = lin.take(expected.len());
-        for i in 0..expected.len() {
-            let val = iter.next().unwrap();
-            assert_f64_near!(val, expected[i]);
+        for val in expected {
+            assert_f64_near!(val, iter.next().unwrap());
         }
     }
 
@@ -286,9 +284,8 @@ mod test {
         // const LIN : Linear<f64,f64,ConstEquidistant<f64>,CollectionWrapper<[f64;4],f64>> = Linear::new_equidistant_unchecked([20.0,100.0,0.0,200.0]);
         let expected = [20.0, 60.0, 100.0, 50.0, 0.0, 100.0, 200.0];
         let mut iter = LIN.take(expected.len());
-        for i in 0..expected.len() {
-            let val = iter.next().unwrap();
-            assert_f64_near!(val, expected[i]);
+        for val in expected {
+            assert_f64_near!(val, iter.next().unwrap());
         }
     }
 
@@ -304,9 +301,8 @@ mod test {
             .unwrap();
         let expected = [20.0, 60.0, 100.0, 50.0, 0.0, 100.0, 200.0];
         let mut iter = linear.sample(samples);
-        for i in 0..expected.len() {
-            let val = iter.next().unwrap();
-            assert_f64_near!(val, expected[i]);
+        for val in expected {
+            assert_f64_near!(val, iter.next().unwrap());
         }
     }
 

--- a/src/linear/mod.rs
+++ b/src/linear/mod.rs
@@ -3,7 +3,7 @@
 //! The easist way to create a linear interpolation is by using the builder pattern of [`LinearBuilder`].
 //!
 //! ```rust
-//! # use enterpolation::{linear::{Linear, LinearError}, Generator, Curve};
+//! # use enterpolation::{linear::{Linear, LinearError}, Signal, Curve};
 //! # use assert_float_eq::{afe_is_f64_near, afe_near_error_msg, assert_f64_near};
 //! #
 //! # fn main() -> Result<(), LinearError> {
@@ -43,7 +43,7 @@
 //! [`equidistant_unchecked()`]: Linear::equidistant_unchecked()
 
 use crate::builder::Unknown;
-use crate::{ConstEquidistant, Curve, DiscreteGenerator, Generator, Identity, SortedGenerator};
+use crate::{Chain, ConstEquidistant, Curve, Identity, Signal, SortedChain};
 use num_traits::real::Real;
 use topology_traits::Merge;
 
@@ -80,7 +80,7 @@ impl Linear<Unknown, Unknown, Unknown> {
     ///
     /// ```rust
     /// # use std::error::Error;
-    /// # use enterpolation::{linear::{Linear, LinearError}, Generator, Curve};
+    /// # use enterpolation::{linear::{Linear, LinearError}, Signal, Curve};
     /// # use assert_float_eq::{afe_is_f64_near, afe_near_error_msg, assert_f64_near};
     /// #
     /// # fn main() -> Result<(), LinearError> {
@@ -107,10 +107,10 @@ impl Linear<Unknown, Unknown, Unknown> {
     }
 }
 
-impl<R, K, E, F> Generator<R> for Linear<K, E, F>
+impl<R, K, E, F> Signal<R> for Linear<K, E, F>
 where
-    K: SortedGenerator<Output = R>,
-    E: DiscreteGenerator,
+    K: SortedChain<Output = R>,
+    E: Chain,
     E::Output: Merge<R> + Debug,
     F: Curve<R, Output = R>,
     R: Real + Debug,
@@ -130,8 +130,8 @@ where
 
 impl<R, K, E, F> Curve<R> for Linear<K, E, F>
 where
-    K: SortedGenerator<Output = R>,
-    E: DiscreteGenerator,
+    K: SortedChain<Output = R>,
+    E: Chain,
     E::Output: Merge<R> + Debug,
     F: Curve<R, Output = R>,
     R: Real + Debug,
@@ -143,9 +143,9 @@ where
 
 impl<K, E, F> Linear<K, E, F>
 where
-    K: SortedGenerator,
+    K: SortedChain,
     K::Output: Real,
-    E: DiscreteGenerator,
+    E: Chain,
     E::Output: Merge<K::Output>,
 {
     /// Create a linear interpolation with slice-like collections of elements and knots.
@@ -169,8 +169,8 @@ where
 
 impl<K, E, F> Linear<K, E, F>
 where
-    E: DiscreteGenerator,
-    K: SortedGenerator,
+    E: Chain,
+    K: SortedChain,
     E::Output: Merge<K::Output>,
     K::Output: Real,
 {

--- a/src/weights/mod.rs
+++ b/src/weights/mod.rs
@@ -7,52 +7,52 @@ mod weighted;
 pub use homogeneous::Homogeneous;
 pub use weighted::Weighted;
 
-use crate::{ConstDiscreteGenerator, Curve, DiscreteGenerator, Generator};
+use crate::{Chain, ConstChain, Curve, Signal};
 use core::ops::Mul;
 use num_traits::identities::Zero;
 use num_traits::real::Real;
 
-/// Generator adaptor to transform `(T,R)` to `Homogeneous<T,R>`.
+/// Signal adaptor to transform `(T,R)` to `Homogeneous<T,R>`.
 ///
-/// Weights given by the generator who equal `R::zero()` are considered to be at infinity.
+/// Weights given by the signal who equal `R::zero()` are considered to be at infinity.
 #[derive(Debug, Copy, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct Weights<G> {
-    gen: G,
+    signal: G,
 }
 
 impl<G> Weights<G> {
-    /// Transform given generator such that it outputs homogeneous data.
-    pub fn new(gen: G) -> Self {
-        Weights { gen }
+    /// Transform given signal such that it outputs homogeneous data.
+    pub fn new(signal: G) -> Self {
+        Weights { signal }
     }
 }
 
-impl<G, Input> Generator<Input> for Weights<G>
+impl<G, Input> Signal<Input> for Weights<G>
 where
-    G: Generator<Input>,
+    G: Signal<Input>,
     G::Output: IntoWeight,
 {
     type Output =
         Homogeneous<<G::Output as IntoWeight>::Element, <G::Output as IntoWeight>::Weight>;
     fn eval(&self, input: Input) -> Self::Output {
-        self.gen.eval(input).into_weight()
+        self.signal.eval(input).into_weight()
     }
 }
 
-impl<G> DiscreteGenerator for Weights<G>
+impl<G> Chain for Weights<G>
 where
-    G: DiscreteGenerator,
+    G: Chain,
     G::Output: IntoWeight,
 {
     fn len(&self) -> usize {
-        self.gen.len()
+        self.signal.len()
     }
 }
 
-impl<G, const N: usize> ConstDiscreteGenerator<N> for Weights<G>
+impl<G, const N: usize> ConstChain<N> for Weights<G>
 where
-    G: ConstDiscreteGenerator<N>,
+    G: ConstChain<N>,
     G::Output: IntoWeight,
 {
 }
@@ -64,13 +64,13 @@ where
     R: Real,
 {
     fn domain(&self) -> [R; 2] {
-        self.gen.domain()
+        self.signal.domain()
     }
 }
 
 /// Trait for all structs which can be transformed into homogeneous data.
 ///
-/// This trait is used to be able to implement Generator for Weights without having to add other generic variables.
+/// This trait is used to be able to implement Signals for Weights without having to add other generic variables.
 pub trait IntoWeight {
     /// The element/direction of the homogeneous data.
     type Element;

--- a/src/weights/mod.rs
+++ b/src/weights/mod.rs
@@ -35,8 +35,8 @@ where
 {
     type Output =
         Homogeneous<<G::Output as IntoWeight>::Element, <G::Output as IntoWeight>::Weight>;
-    fn gen(&self, input: Input) -> Self::Output {
-        self.gen.gen(input).into_weight()
+    fn eval(&self, input: Input) -> Self::Output {
+        self.gen.eval(input).into_weight()
     }
 }
 

--- a/src/weights/weighted.rs
+++ b/src/weights/weighted.rs
@@ -1,7 +1,7 @@
 //! The adaptor `Weighted` can be used for all interpolations to hide the inner workings of a weighted element.
 
 use crate::weights::Homogeneous;
-use crate::{Curve, Generator};
+use crate::{Curve, Signal};
 use core::ops::Div;
 use num_traits::real::Real;
 
@@ -16,8 +16,8 @@ pub struct Weighted<G> {
 
 impl<G> Weighted<G> {
     /// Use the `Weighted` Adaptor on the given weighted interpolation to automatically unwrap the elements of their weight.
-    pub fn new(gen: G) -> Self {
-        Weighted { inner: gen }
+    pub fn new(signal: G) -> Self {
+        Weighted { inner: signal }
     }
     /// Return the inner interpolation.
     pub fn inner(self) -> G {
@@ -25,9 +25,9 @@ impl<G> Weighted<G> {
     }
 }
 
-impl<G, I> Generator<I> for Weighted<G>
+impl<G, I> Signal<I> for Weighted<G>
 where
-    G: Generator<I>,
+    G: Signal<I>,
     G::Output: Project,
 {
     type Output = <G::Output as Project>::Element;
@@ -47,7 +47,7 @@ where
     }
 }
 
-/// This trait is used to be able to implement Generator for Weights without having to add other generic variables.
+/// This trait is used to be able to implement Signal for Weights without having to add other generic variables.
 pub trait Project {
     type Element;
     type Weight;

--- a/src/weights/weighted.rs
+++ b/src/weights/weighted.rs
@@ -31,8 +31,8 @@ where
     G::Output: Project,
 {
     type Output = <G::Output as Project>::Element;
-    fn gen(&self, input: I) -> Self::Output {
-        self.inner.gen(input).project()
+    fn eval(&self, input: I) -> Self::Output {
+        self.inner.eval(input).project()
     }
 }
 


### PR DESCRIPTION
This introduces breaking changes:

- Renamed `Generator::gen()` to `Signal::eval()`
- Renamed `DiscreteGenerator` to `Chain`
- Renamed `ConstDiscreteGenerator` to `ConstChain`
- Renamed `SortedGenerator` to `SortedChain`


Resolves #31